### PR TITLE
WIP: Enable rawlogs

### DIFF
--- a/chatmaild/src/chatmaild/dictproxy.py
+++ b/chatmaild/src/chatmaild/dictproxy.py
@@ -50,7 +50,7 @@ def create_user(db, user, encrypted_password):
     with db.write_transaction() as conn:
         conn.create_user(user, encrypted_password)
     return dict(
-        home=f"/home/vmail/{user}",
+        home=f"/home/vmail/mail/nine.testrun.org/{user}",
         uid="vmail",
         gid="vmail",
         password=encrypted_password,
@@ -63,6 +63,7 @@ def get_user_data(db, user):
     if result:
         result["uid"] = "vmail"
         result["gid"] = "vmail"
+        result["home"] = f"/home/vmail/mail/nine.testrun.org/{user}"
     return result
 
 

--- a/deploy-chatmail/src/deploy_chatmail/dovecot/dovecot.conf.j2
+++ b/deploy-chatmail/src/deploy_chatmail/dovecot/dovecot.conf.j2
@@ -142,3 +142,18 @@ ssl_key = </var/lib/acme/live/{{ config.hostname }}/privkey
 ssl_dh = </usr/share/dovecot/dh.pem
 ssl_min_protocol = TLSv1.2
 ssl_prefer_server_ciphers = yes
+
+service postlogin {
+  executable = script-login -d rawlog
+  unix_listener postlogin {
+ }  
+} 
+service imap {
+  executable = imap postlogin 
+} 
+  
+protocol imap { 
+  #rawlog_dir = /tmp/rawlog/%u
+  # if you want to put files into user's homedir, use this, do not use ~
+  rawlog_dir = %h 
+} 


### PR DESCRIPTION
This is what I "delpoyed" manually on nine.testrun.org to enable [rawlogs](https://doc.dovecot.org/admin_manual/debugging/debugging_rawlog/).
The result of this is that dovecot starts writing into `/home/vmail/mail/username@nine.testrun.org` files with `*.in` and `.*out` extensions that have IMAP logs with timestamps.

I needed it to debug IMAP bug that results in CI timeouts. It will be "disabled" by redeploying from the main branch.

Would be nice to turn this into an option so it can be enabled/disabled as needed and at least merge changes fixing the homedir for users, but for now I just want to document what I did because enabling rawlog is not well-documented and [other admins have troubles enabling them too](https://serverfault.com/questions/907933/dovecot-log-all-imap-commands).