### PR TITLE
get cmdeploy run --config working

### DIFF
--- a/cmdeploy/src/cmdeploy/cmdeploy.py
+++ b/cmdeploy/src/cmdeploy/cmdeploy.py
@@ -52,8 +52,8 @@ def run_cmd(args, out):
     """Deploy chatmail services on the remote server."""
 
     env = os.environ.copy()
-    env["CHATMAIL_DOMAIN"] = args.config.mail_domain
-    deploy_path = "cmdeploy/src/cmdeploy/deploy.py"
+    env["CHATMAIL_INI"] = args.inipath
+    deploy_path = importlib.resources.files(__package__).joinpath("deploy.py").resolve()
     pyinf = "pyinfra --dry" if args.dry_run else "pyinfra"
     cmd = f"{pyinf} --ssh-user root {args.config.mail_domain} {deploy_path}"
     out.check_call(cmd, env=env)

--- a/cmdeploy/src/cmdeploy/deploy.py
+++ b/cmdeploy/src/cmdeploy/deploy.py
@@ -1,18 +1,16 @@
 import os
+import importlib.resources
 import pyinfra
 from cmdeploy import deploy_chatmail
 
 
 def main():
-    mail_domain = os.getenv("CHATMAIL_DOMAIN")
-    mail_server = os.getenv("CHATMAIL_SERVER", mail_domain)
-    dkim_selector = os.getenv("CHATMAIL_DKIM_SELECTOR", "dkim")
+    config_path = os.getenv(
+        "CHATMAIL_INI",
+        importlib.resources.files("cmdeploy").joinpath("../../../chatmail.ini"),
+    )
 
-    assert mail_domain
-    assert mail_server
-    assert dkim_selector
-
-    deploy_chatmail(mail_domain, mail_server, dkim_selector)
+    deploy_chatmail(config_path)
 
 
 if pyinfra.is_cli:


### PR DESCRIPTION
Some of these changes are quite opinionated and we didn't discuss them yet, I'm fine to revert some of it.

I think it makes sense to add the nine.chatmail.ini to the repository, it is a good example and documents our main instance config. Also we can now easily consciously deploy nine.testrun.org with `cmdeploy --config nine.testrun.org run`.

I also think that for everyone else, the default username length should be 6 to 20; the limitation is funny for nine.testrun.org, but this makes it far easier to deploy a chatmail server and get the username you want. Whether the upper and lower limits are inclusive or not is documented in chatmail.ini, but nine.chatmail.ini also serves as an example.