### PR TITLE
Use more characters for passwords

### DIFF
--- a/chatmaild/src/chatmaild/newemail.py
+++ b/chatmaild/src/chatmaild/newemail.py
@@ -9,12 +9,17 @@ from chatmaild.config import read_config, Config
 
 CONFIG_PATH = "/usr/local/lib/chatmaild/chatmail.ini"
 ALPHANUMERIC = "abcdefghijklmnopqrstuvwxyz1234567890"
-ALPHANUMERIC_PUNCT = r"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!#$%&'()*+,-./:;<=>?@[\]^_`{|}~." + r'"'
+ALPHANUMERIC_PUNCT = (
+    r"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!#$%&'()*+,-./:;<=>?@[\]^_`{|}~."
+    + r'"'
+)
 
 
 def create_newemail_dict(config: Config):
     user = "".join(random.choices(ALPHANUMERIC, k=config.username_min_length))
-    password = "".join(random.choices(ALPHANUMERIC_PUNCT, k=config.password_min_length + 3))
+    password = "".join(
+        random.choices(ALPHANUMERIC_PUNCT, k=config.password_min_length + 3)
+    )
     return dict(email=f"{user}@{config.mail_domain}", password=f"{password}")
 
 

--- a/chatmaild/src/chatmaild/newemail.py
+++ b/chatmaild/src/chatmaild/newemail.py
@@ -4,21 +4,21 @@
 
 import json
 import random
+import secrets
+import string
 
 from chatmaild.config import read_config, Config
 
 CONFIG_PATH = "/usr/local/lib/chatmaild/chatmail.ini"
-ALPHANUMERIC = "abcdefghijklmnopqrstuvwxyz1234567890"
-ALPHANUMERIC_PUNCT = (
-    r"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!#$%&'()*+,-./:;<=>?@[\]^_`{|}~."
-    + r'"'
-)
+ALPHANUMERIC = string.ascii_lowercase + string.digits
+ALPHANUMERIC_PUNCT = string.ascii_letters + string.digits + string.punctuation
 
 
 def create_newemail_dict(config: Config):
     user = "".join(random.choices(ALPHANUMERIC, k=config.username_min_length))
     password = "".join(
-        random.choices(ALPHANUMERIC_PUNCT, k=config.password_min_length + 3)
+        secrets.choice(ALPHANUMERIC_PUNCT)
+        for _ in range(config.password_min_length + 3)
     )
     return dict(email=f"{user}@{config.mail_domain}", password=f"{password}")
 

--- a/chatmaild/src/chatmaild/newemail.py
+++ b/chatmaild/src/chatmaild/newemail.py
@@ -8,12 +8,13 @@ import random
 from chatmaild.config import read_config, Config
 
 CONFIG_PATH = "/usr/local/lib/chatmaild/chatmail.ini"
+ALPHANUMERIC = "abcdefghijklmnopqrstuvwxyz1234567890"
+ALPHANUMERIC_PUNCT = r"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890!#$%&'()*+,-./:;<=>?@[\]^_`{|}~." + r'"'
 
 
 def create_newemail_dict(config: Config):
-    alphanumeric = "abcdefghijklmnopqrstuvwxyz1234567890"
-    user = "".join(random.choices(alphanumeric, k=config.username_min_length))
-    password = "".join(random.choices(alphanumeric, k=config.password_min_length + 3))
+    user = "".join(random.choices(ALPHANUMERIC, k=config.username_min_length))
+    password = "".join(random.choices(ALPHANUMERIC_PUNCT, k=config.password_min_length + 3))
     return dict(email=f"{user}@{config.mail_domain}", password=f"{password}")
 
 


### PR DESCRIPTION
This expands the character set used for passwords generated for new
accounts.  The set it taken from the set used by the pass tool.  The
special characters is the full GNU grep [:punct:] set.