### PR TITLE
fix: align spelling of Delta Chat

### DIFF
--- a/www/src/privacy.md
+++ b/www/src/privacy.md
@@ -62,7 +62,7 @@ we process the following data and details:
 Creating an account happens in one of two ways on our mail servers: 
 
 - with a QR invitation token 
-  which is scanned using the DeltaChat app
+  which is scanned using the Delta Chat app
   and then the account is created.
 
 - by letting Delta Chat otherwise create an account 


### PR DESCRIPTION
Add a single space to DeltaChat so it aligns how it is written in the rest of the document