### PR TITLE
Let acmetool manage port 80

### DIFF
--- a/cmdeploy/src/cmdeploy/acmetool/__init__.py
+++ b/cmdeploy/src/cmdeploy/acmetool/__init__.py
@@ -1,6 +1,6 @@
 import importlib.resources
 
-from pyinfra.operations import apt, files, server
+from pyinfra.operations import apt, files, systemd, server
 
 
 def deploy_acmetool(nginx_hook=False, email="", domains=[]):
@@ -44,6 +44,23 @@ def deploy_acmetool(nginx_hook=False, email="", domains=[]):
         user="root",
         group="root",
         mode="644",
+    )
+
+    service_file = files.put(
+        src=importlib.resources.files(__package__).joinpath(
+            "acmetool-redirector.service"
+        ),
+        dest="/etc/systemd/system/acmetool-redirector.service",
+        user="root",
+        group="root",
+        mode="644",
+    )
+    systemd.service(
+        name="Setup acmetool-redirector service",
+        service="acmetool-redirector.service",
+        running=True,
+        enabled=True,
+        restarted=service_file.changed,
     )
 
     server.shell(

--- a/cmdeploy/src/cmdeploy/acmetool/acmetool-redirector.service
+++ b/cmdeploy/src/cmdeploy/acmetool/acmetool-redirector.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=acmetool HTTP redirector
+
+[Service]
+Type=notify
+ExecStart=/usr/bin/acmetool redirector --service.uid=daemon
+Restart=always
+RestartSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
+++ b/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
@@ -48,12 +48,4 @@ http {
         # add cgi-bin support
         include /usr/share/doc/fcgiwrap/examples/nginx.conf;
 	}
-    server {
-        listen 80 default_server;
-        listen [::]:80 default_server;
-        server_name _;
-
-        return 301 https://$host$request_uri;
-    }
 }
-


### PR DESCRIPTION
This avoids circular dependency with nginx.
nginx needs a certificate to start
and getting a certificate requires someone
listening on port 80.

Fixes #133