### PR TITLE
Update master.cf.j2

### DIFF
--- a/cmdeploy/src/cmdeploy/postfix/master.cf.j2
+++ b/cmdeploy/src/cmdeploy/postfix/master.cf.j2
@@ -34,6 +34,7 @@ submission inet n       -       y       -       -       smtpd
   -o milter_macro_daemon_name=ORIGINATING
   -o smtpd_client_connection_count_limit=1000
   -o smtpd_proxy_filter=127.0.0.1:{{ config.filtermail_smtp_port }}
+  -o cleanup_service_name=submission-header-cleanup
 smtps     inet  n       -       y       -       -       smtpd
   -o syslog_name=postfix/smtps
   -o smtpd_tls_wrappermode=yes
@@ -80,3 +81,8 @@ filter    unix -        n       n       -       -       lmtp
 # Local SMTP server for reinjecting filered mail.
 localhost:{{ config.postfix_reinject_port }} inet  n       -       n       -       10      smtpd
   -o syslog_name=postfix/reinject
+###
+### Cleanup-Service um MUA header zu entfernen
+###
+submission-header-cleanup unix n - n    -       0       cleanup
+    -o header_checks=regexp:/etc/postfix/submission_header_cleanup


### PR DESCRIPTION
Add submission-header-cleanup to reduce the meta-data

Main critcal comments on chating via eMail is the mass of Meta-Data.

To activate submission-header-cleanup, just a few lines had to add to master.cf.

The filterfile ist found at `/etc/postfix/submission_header_cleanup` and looks like that:

```
### Entfernt Datenschutz-relevante Header aus E-Mails von MTUAs

/^Received:/            IGNORE
/^X-Originating-IP:/    IGNORE
/^X-Mailer:/            IGNORE
/^User-Agent:/          IGNORE
```
