### PR TITLE
config: add xstore and groupsbot to default passthrough_recipients

### DIFF
--- a/chatmaild/src/chatmaild/ini/chatmail.ini.f
+++ b/chatmaild/src/chatmaild/ini/chatmail.ini.f
@@ -33,7 +33,7 @@ password_min_length = 9
 passthrough_senders =
 
 # list of e-mail recipients for which to accept outbound un-encrypted mails
-passthrough_recipients =
+passthrough_recipients = xstore@testrun.org groupsbot@hispanilandia.net
 
 #
 # Deployment Details

--- a/chatmaild/src/chatmaild/ini/override-testrun.ini
+++ b/chatmaild/src/chatmaild/ini/override-testrun.ini
@@ -1,7 +1,7 @@
 
 [privacy]
 
-passthrough_recipients = privacy@testrun.org
+passthrough_recipients = privacy@testrun.org xstore@testrun.org groupsbot@hispanilandia.net
 
 privacy_postal =
     Merlinux GmbH, Represented by the managing director H. Krekel,

--- a/chatmaild/src/chatmaild/tests/test_config.py
+++ b/chatmaild/src/chatmaild/tests/test_config.py
@@ -28,5 +28,5 @@ def test_read_config_testrun(make_config):
     assert config.username_min_length == 9
     assert config.username_max_length == 9
     assert config.password_min_length == 9
-    assert config.passthrough_recipients == ["privacy@testrun.org"]
+    assert "privacy@testrun.org" in config.passthrough_recipients
     assert config.passthrough_senders == []


### PR DESCRIPTION
This way, nine.testrun.org users can easily join groups and use the xstore. Additional benefit - admins can see the separator for lists in chatmail.ini at one glance.