### PR TITLE
www: change nine.testrun.org occurence to mail_domain

### DIFF
--- a/www/src/info.md
+++ b/www/src/info.md
@@ -3,7 +3,7 @@
 
 ## More information 
 
-`nine.testrun.org` provides a low-maintenance, resource efficient and 
+{{ config.mail_domain }} provides a low-maintenance, resource efficient and 
 interoperable e-mail service for everyone. What's behind a `chatmail` is 
 effectively a normal e-mail address just like any other but optimized 
 for the usage in chats, especially DeltaChat.


### PR DESCRIPTION
https://daleth.cafe/info.html doesn't have a reason to say "nine.testrun.org" ;)