### PR TITLE
Update nginx.conf.j2

### DIFF
--- a/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
+++ b/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
@@ -26,6 +26,8 @@ http {
 	gzip on;
 
 	server {
+                server_name {{ config.domain_name }} www.{{ config.domain_name }} _;if ( $host != $server_name ) {    return 301 https://$server_name$request_uri;}
+		# alternative to https:// $sheme 
 		listen 443 ssl default_server;
 		listen [::]:443 ssl default_server;
 


### PR DESCRIPTION
For more SEO-friendly, www should have a CNAME and a canonical redirect into the nginx.conf.