### PR TITLE
Hardening Postfix

### DIFF
--- a/cmdeploy/src/cmdeploy/postfix/main.cf.j2
+++ b/cmdeploy/src/cmdeploy/postfix/main.cf.j2
@@ -50,3 +50,9 @@ smtpd_milters = unix:opendkim/opendkim.sock
 non_smtpd_milters = $smtpd_milters
 
 header_checks = regexp:/etc/postfix/submission_header_cleanup
+smtpd_discard_ehlo_keywords = silent-discard,pipelining
+disable_vrfy_command=yes
+
+mua_client_restrictions = permit_sasl_authenticated, reject
+mua_sender_restrictions = permit_sasl_authenticated, reject
+mua_helo_restrictions = permit_mynetworks, reject_non_fqdn_hostname, reject_invalid_hostname, permit


### PR DESCRIPTION
Forbid smuggeling. It's not important, if we use it or if we have the possibility to pipe eMails, but it's imortant, that it is not part of SMTP. It is made from "the others", a technology, that is not our own.

VRFY: 
RFC 2821

4.1.1.6 VERIFY (VRFY)

This command asks the receiver to confirm that the argument identifies a user or mailbox. If it is a user name, information is returned as specified in section 3.5.

This command has no effect on the reverse-path buffer, the forward- path buffer, or the mail data buffer.

Syntax:
"VRFY" SP String CRLF


7.3 VRFY, EXPN, and Security

As discussed in section 3.5, individual sites may want to disable either or both of VRFY or EXPN for security reasons. As a corollary to the above, implementations that permit this MUST NOT appear to have verified addresses that are not, in fact, verified. If a site

disables these commands for security reasons, the SMTP server MUST return a 252 response, rather than a code that could be confused with successful or unsuccessful verification.

Returning a 250 reply code with the address listed in the VRFY command after having checked it only for syntax violates this rule. Of course, an implementation that "supports" VRFY by always returning 550 whether or not the address is valid is equally not in conformance.

Within the last few years, the contents of mailing lists have become popular as an address information source for so-called "spammers." The use of EXPN to "harvest" addresses has increased as list administrators have installed protections against inappropriate uses of the lists themselves. Implementations SHOULD still provide support for EXPN, but sites SHOULD carefully evaluate the tradeoffs. As authentication mechanisms are introduced into SMTP, some sites may choose to make EXPN available only to authenticated requestors.

Last thre lines are not defined variables in master.cf. Have to be defined for a better audit.