### PR TITLE
Remove postscreen-related entries from Postfix master.cf

### DIFF
--- a/cmdeploy/src/cmdeploy/postfix/master.cf.j2
+++ b/cmdeploy/src/cmdeploy/postfix/master.cf.j2
@@ -14,10 +14,6 @@ smtp      inet  n       -       y       -       -       smtpd -v
 {% else %}
 smtp      inet  n       -       y       -       -       smtpd 
 {% endif %}
-#smtp      inet  n       -       y       -       1       postscreen
-#smtpd     pass  -       -       y       -       -       smtpd
-#dnsblog   unix  -       -       y       -       0       dnsblog
-#tlsproxy  unix  -       -       y       -       0       tlsproxy
 submission inet n       -       y       -       -       smtpd
   -o syslog_name=postfix/submission
   -o smtpd_tls_security_level=encrypt


### PR DESCRIPTION
All these entries are related to `postscreen` service which is currently not enabled.

For documentation see https://www.postfix.org/POSTSCREEN_README.html

If we later want to enable it, we can readd uncommented entries and document it.