### PR TITLE
Update `pip` and `setuptools` in scripts/initenv.sh

### DIFF
--- a/scripts/initenv.sh
+++ b/scripts/initenv.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-python3 -m venv venv
+python3 -m venv --upgrade-deps venv
 
 venv/bin/pip install -e chatmaild 
 venv/bin/pip install -e cmdeploy


### PR DESCRIPTION
This is to support Debian 11 which ships setuptools that do not support `-e` without setup.py

Fixes #192 