### PR TITLE
tests: add test that we don't leak email addresses via VRFY

### DIFF
--- a/cmdeploy/src/cmdeploy/tests/online/test_0_login.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_0_login.py
@@ -1,6 +1,7 @@
 import pytest
 import threading
 import queue
+import socket
 
 from chatmaild.config import read_config
 from cmdeploy.cmdeploy import main
@@ -78,3 +79,24 @@ def test_concurrent_logins_same_account(
 
     for _ in conns:
         assert login_results.get()
+
+
+def test_no_vrfy(chatmail_config):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.connect((chatmail_config.mail_domain, 25))
+    banner = sock.recv(1024)
+    print(banner)
+    sock.send(b"VRFY wrongaddress@%s\r\n" % (chatmail_config.mail_domain.encode(),))
+    result = sock.recv(1024)
+    print(result)
+    sock.send(b"VRFY echo@%s\r\n" % (chatmail_config.mail_domain.encode(),))
+    result2 = sock.recv(1024)
+    print(result2)
+    assert result[0:10] == result2[0:10]
+    sock.send(b"VRFY wrongaddress\r\n")
+    result = sock.recv(1024)
+    print(result)
+    sock.send(b"VRFY echo\r\n")
+    result2 = sock.recv(1024)
+    print(result2)
+    assert result[0:10] == result2[0:10] == b"252 2.0.0 "


### PR DESCRIPTION
It seems we already return 252 for every VRFY command, so we neither confirm nor deny that a mailbox exists on the server. This is the desired behavior. I nonetheless added a test to avoid regressions.

This means our postfix is sufficiently hardened, I think?

replaces #168 