### PR TITLE
Implement "iterate" command in metadata server

### DIFF
--- a/chatmaild/src/chatmaild/metadata.py
+++ b/chatmaild/src/chatmaild/metadata.py
@@ -15,6 +15,7 @@ import requests
 
 
 DICTPROXY_LOOKUP_CHAR = "L"
+DICTPROXY_ITERATE_CHAR = "I"
 DICTPROXY_SET_CHAR = "S"
 DICTPROXY_BEGIN_TRANSACTION_CHAR = "B"
 DICTPROXY_COMMIT_TRANSACTION_CHAR = "C"
@@ -74,6 +75,10 @@ def handle_dovecot_request(msg, transactions, notifier):
     parts = msg[1:].split("\t")
     if short_command == DICTPROXY_LOOKUP_CHAR:
         return "N\n"
+    elif short_command == DICTPROXY_ITERATE_CHAR:
+        # Empty line means ITER_FINISHED.
+        # If we don't return empty line Dovecot will timeout.
+        return "\n"
 
     if short_command not in (DICTPROXY_TRANSACTION_CHARS):
         return

--- a/chatmaild/src/chatmaild/tests/test_metadata.py
+++ b/chatmaild/src/chatmaild/tests/test_metadata.py
@@ -70,6 +70,21 @@ def test_handle_dovecot_protocol_set_devicetoken():
     assert wfile.getvalue() == b"O\n"
 
 
+def test_handle_dovecot_protocol_iterate():
+    rfile = io.BytesIO(
+        b"\n".join(
+            [
+                b"H",
+                b"I9\t0\tpriv/5cbe730f146fea6535be0d003dd4fc98/\tci-2dzsrs@nine.testrun.org",
+            ]
+        )
+    )
+    wfile = io.BytesIO()
+    notifier = Notifier()
+    handle_dovecot_protocol(rfile, wfile, notifier)
+    assert wfile.getvalue() == b"\n"
+
+
 def test_handle_dovecot_protocol_messagenew():
     rfile = io.BytesIO(
         b"\n".join(


### PR DESCRIPTION
Otherwise Dovecot times out when trying to iterate over metadata of the folder. Apparently it happens when attempting to delete folder from the server over IMAP.