### PR TITLE
fix runtime dovecot/sieve-compile error on every incoming message

### DIFF
--- a/cmdeploy/src/cmdeploy/__init__.py
+++ b/cmdeploy/src/cmdeploy/__init__.py
@@ -359,6 +359,13 @@ def _configure_dovecot(config: Config, debug: bool = False) -> bool:
         mode="644",
     )
     need_restart |= sieve_script.changed
+    if sieve_script.changed:
+        server.shell(
+            name=f"compile sieve script",
+            commands=[
+                f"/usr/bin/sievec /etc/dovecot/default.sieve"
+            ],
+        )
 
     files.template(
         src=importlib.resources.files(__package__).joinpath("dovecot/expunge.cron.j2"),

--- a/cmdeploy/src/cmdeploy/dovecot/default.sieve
+++ b/cmdeploy/src/cmdeploy/dovecot/default.sieve
@@ -1,5 +1,7 @@
 require ["imap4flags"];
 
+# flag the message so it doesn't cause a push notification
+
 if header :is ["Auto-Submitted"] ["auto-replied", "auto-generated"] {
 	addflag "$Auto";
 }


### PR DESCRIPTION
this PR pre-compiles the sieve-script added for ios push notifications .... 

in particular it fixes this error which made dovecot compile the (small) sieve script but then fail to write to `/etc/dovecot` the resulting "svbin" and so it would retry that on every incoming message. 
The comment in `default.sieve` is mostly to force the compile-step on all chatmail services. 

```
Mär 20 14:23:36 c2 dovecot[54426]: lmtp(ac1_vkst1@c2.testrun.org)<54671><iHSYH2jx+mWP1QAAwVJQ4w>: Error: open(/etc/dovecot/default.svbin.c2.54671.69dff114ef729adb) failed: Read-only file system
Mär 20 14:23:36 c2 dovecot[54426]: lmtp(ac1_vkst1@c2.testrun.org)<54671><iHSYH2jx+mWP1QAAwVJQ4w>: Error: sieve: binary /etc/dovecot/default.svbin: save: failed to create temporary file: open(/etc/dovecot/default.svbin.) failed: Read-only file system
```