### PR TITLE
add persistent metadata/token storage

### DIFF
--- a/chatmaild/src/chatmaild/chatmail-metadata.service.f
+++ b/chatmaild/src/chatmaild/chatmail-metadata.service.f
@@ -2,7 +2,7 @@
 Description=Chatmail dict proxy for IMAP METADATA
 
 [Service]
-ExecStart={execpath} /run/dovecot/metadata.socket vmail {config_path}
+ExecStart={execpath} /run/dovecot/metadata.socket vmail {config_path} /home/vmail/metadata
 Restart=always
 RestartSec=30
 

--- a/chatmaild/src/chatmaild/metadata.py
+++ b/chatmaild/src/chatmaild/metadata.py
@@ -23,12 +23,16 @@ DICTPROXY_TRANSACTION_CHARS = "SBC"
 
 
 class Notifier:
-    def __init__(self):
+    def __init__(self, metadata_dir):
+        self.metadata_dir = metadata_dir
         self.guid2token = {}
         self.to_notify_queue = Queue()
 
     def set_token(self, guid, token):
         self.guid2token[guid] = token
+
+    def get_token(self, guid):
+        return self.guid2token.get(guid)
 
     def new_message_for_guid(self, guid):
         self.to_notify_queue.put(guid)
@@ -40,7 +44,7 @@ class Notifier:
 
     def thread_run_one(self, requests_session):
         guid = self.to_notify_queue.get()
-        token = self.guid2token.get(guid)
+        token = self.get_token(guid)
         if token:
             response = requests_session.post(
                 "https://notifications.delta.chat/notify",

--- a/chatmaild/src/chatmaild/metadata.py
+++ b/chatmaild/src/chatmaild/metadata.py
@@ -1,5 +1,6 @@
 import pwd
 
+import pathlib
 from queue import Queue
 from threading import Thread
 from socketserver import (
@@ -145,12 +146,15 @@ class ThreadedUnixStreamServer(ThreadingMixIn, UnixStreamServer):
 
 
 def main():
-    socket, username, config = sys.argv[1:]
+    socket, username, config, metadata_dir = sys.argv[1:]
     passwd_entry = pwd.getpwnam(username)
 
     # XXX config is not currently used
     config = read_config(config)
-    notifier = Notifier()
+    metadata_dir = pathlib.Path(metadata_dir)
+    if not metadata_dir.exists():
+        metadata_dir.mkdir()
+    notifier = Notifier(metadata_dir)
 
     class Handler(StreamRequestHandler):
         def handle(self):

--- a/chatmaild/src/chatmaild/tests/test_metadata.py
+++ b/chatmaild/src/chatmaild/tests/test_metadata.py
@@ -11,8 +11,7 @@ from chatmaild.metadata import (
 @pytest.fixture
 def notifier(tmp_path):
     metadata_dir = tmp_path.joinpath("metadata")
-    if not metadata_dir.exists():
-        metadata_dir.mkdir()
+    metadata_dir.mkdir()
     return Notifier(metadata_dir)
 
 

--- a/chatmaild/src/chatmaild/tests/test_metadata.py
+++ b/chatmaild/src/chatmaild/tests/test_metadata.py
@@ -16,6 +16,22 @@ def notifier(tmp_path):
     return Notifier(metadata_dir)
 
 
+def test_notifier_persistence(tmp_path):
+    metadata_dir = tmp_path.joinpath("metadata")
+    metadata_dir.mkdir()
+    notifier1 = Notifier(metadata_dir)
+    notifier2 = Notifier(metadata_dir)
+    assert notifier1.get_token(guid="guid00") is None
+    assert notifier2.get_token(guid="guid00") is None
+
+    notifier1.set_token("guid00", "01234")
+    notifier1.set_token("guid03", "456")
+    assert notifier2.get_token("guid00") == "01234"
+    assert notifier2.get_token("guid03") == "456"
+    notifier2.del_token("guid00")
+    assert notifier1.get_token("guid00") is None
+
+
 def test_handle_dovecot_request_lookup_fails(notifier):
     res = handle_dovecot_request("Lpriv/123/chatmail", {}, notifier)
     assert res == "N\n"


### PR DESCRIPTION
fixes #238 

note that i use "marshal", the python interpreter fast marshalling of basic data types. A dict[string->string] is pretty safe to marshal and demarshal, so nothing more fancy is needed.  Also tested that python3.6 and python3.10 can read/write the marhsalled data.  
