### PR TITLE
store devicetokens inside per-user mailboxdir, allow multiple tokens per account, support GETMETADATA and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changes since March 15th, 2024
 
+- Persist push tokens and support multiple device per address 
+  ([#254](https://github.com/deltachat/chatmail/pull/254))
+
 - Avoid warning for regular doveauth protocol's hello message. 
   ([#250](https://github.com/deltachat/chatmail/pull/250))
 

--- a/chatmaild/pyproject.toml
+++ b/chatmaild/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
   "iniconfig",
   "deltachat-rpc-server",
   "deltachat-rpc-client",
+  "filelock",
   "requests",
 ]
 

--- a/chatmaild/src/chatmaild/chatmail-metadata.service.f
+++ b/chatmaild/src/chatmaild/chatmail-metadata.service.f
@@ -2,7 +2,7 @@
 Description=Chatmail dict proxy for IMAP METADATA
 
 [Service]
-ExecStart={execpath} /run/dovecot/metadata.socket vmail {config_path} /home/vmail/metadata
+ExecStart={execpath} /run/dovecot/metadata.socket vmail /home/vmail/mail/{mail_domain}
 Restart=always
 RestartSec=30
 

--- a/chatmaild/src/chatmaild/filedict.py
+++ b/chatmaild/src/chatmaild/filedict.py
@@ -1,0 +1,37 @@
+import os
+import logging
+import marshal
+import filelock
+from contextlib import contextmanager
+
+
+class FileDict:
+    """Concurrency-safe multi-reader-single-writer Persistent Dict."""
+
+    def __init__(self, path, timeout=5.0):
+        self.path = path
+        self.lock_path = path.with_name(path.name + ".lock")
+        self.timeout = timeout
+
+    @contextmanager
+    def modify(self):
+        try:
+            with filelock.FileLock(self.lock_path, timeout=self.timeout):
+                data = self.read()
+                yield data
+                write_path = self.path.with_suffix(".tmp")
+                with write_path.open("wb") as f:
+                    marshal.dump(data, f)
+                os.rename(write_path, self.path)
+        except filelock.Timeout:
+            logging.warning("could not obtain lock, removing: %r", self.lock_path)
+            os.remove(self.lock_path)
+            with self.modify() as d:
+                yield d
+
+    def read(self):
+        try:
+            with self.path.open("rb") as f:
+                return marshal.load(f)
+        except FileNotFoundError:
+            return {}

--- a/chatmaild/src/chatmaild/filedict.py
+++ b/chatmaild/src/chatmaild/filedict.py
@@ -8,26 +8,21 @@ from contextlib import contextmanager
 class FileDict:
     """Concurrency-safe multi-reader-single-writer Persistent Dict."""
 
-    def __init__(self, path, timeout=5.0):
+    def __init__(self, path):
         self.path = path
         self.lock_path = path.with_name(path.name + ".lock")
-        self.timeout = timeout
 
     @contextmanager
     def modify(self):
-        try:
-            with filelock.FileLock(self.lock_path, timeout=self.timeout):
-                data = self.read()
-                yield data
-                write_path = self.path.with_suffix(".tmp")
-                with write_path.open("wb") as f:
-                    marshal.dump(data, f)
-                os.rename(write_path, self.path)
-        except filelock.Timeout:
-            logging.warning("could not obtain lock, removing: %r", self.lock_path)
-            os.remove(self.lock_path)
-            with self.modify() as d:
-                yield d
+        # the OS will release the lock if the process dies,
+        # and the contextmanager will otherwise guarantee release
+        with filelock.FileLock(self.lock_path):
+            data = self.read()
+            yield data
+            write_path = self.path.with_suffix(".tmp")
+            with write_path.open("wb") as f:
+                marshal.dump(data, f)
+            os.rename(write_path, self.path)
 
     def read(self):
         try:

--- a/chatmaild/src/chatmaild/filedict.py
+++ b/chatmaild/src/chatmaild/filedict.py
@@ -31,5 +31,5 @@ class FileDict:
         except FileNotFoundError:
             return {}
         except Exception:
-            logging.warning("corrupt marshal data at: %r", self.path)
+            logging.warning("corrupt serialization state at: %r", self.path)
             return {}

--- a/chatmaild/src/chatmaild/filedict.py
+++ b/chatmaild/src/chatmaild/filedict.py
@@ -19,7 +19,7 @@ class FileDict:
         with filelock.FileLock(self.lock_path):
             data = self.read()
             yield data
-            write_path = self.path.with_suffix(".tmp")
+            write_path = self.path.with_name(self.path.name + ".tmp")
             with write_path.open("w") as f:
                 json.dump(data, f)
             os.rename(write_path, self.path)

--- a/chatmaild/src/chatmaild/filedict.py
+++ b/chatmaild/src/chatmaild/filedict.py
@@ -1,6 +1,6 @@
 import os
 import logging
-import marshal
+import json
 import filelock
 from contextlib import contextmanager
 
@@ -20,14 +20,14 @@ class FileDict:
             data = self.read()
             yield data
             write_path = self.path.with_suffix(".tmp")
-            with write_path.open("wb") as f:
-                marshal.dump(data, f)
+            with write_path.open("w") as f:
+                json.dump(data, f)
             os.rename(write_path, self.path)
 
     def read(self):
         try:
-            with self.path.open("rb") as f:
-                return marshal.load(f)
+            with self.path.open("r") as f:
+                return json.load(f)
         except FileNotFoundError:
             return {}
         except Exception:

--- a/chatmaild/src/chatmaild/filedict.py
+++ b/chatmaild/src/chatmaild/filedict.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 
 
 class FileDict:
-    """Concurrency-safe multi-reader-single-writer Persistent Dict."""
+    """Concurrency-safe multi-reader/single-writer persistent dict."""
 
     def __init__(self, path):
         self.path = path

--- a/chatmaild/src/chatmaild/filedict.py
+++ b/chatmaild/src/chatmaild/filedict.py
@@ -35,3 +35,6 @@ class FileDict:
                 return marshal.load(f)
         except FileNotFoundError:
             return {}
+        except Exception:
+            logging.warning("corrupt marshal data at: %r", self.path)
+            return {}

--- a/chatmaild/src/chatmaild/metadata.py
+++ b/chatmaild/src/chatmaild/metadata.py
@@ -8,7 +8,6 @@ from socketserver import (
     StreamRequestHandler,
     ThreadingMixIn,
 )
-from .config import read_config
 import sys
 import logging
 import os
@@ -147,15 +146,16 @@ class ThreadedUnixStreamServer(ThreadingMixIn, UnixStreamServer):
 
 
 def main():
-    socket, username, config, metadata_dir = sys.argv[1:]
+    socket, username, vmail_dir = sys.argv[1:]
     passwd_entry = pwd.getpwnam(username)
 
-    # XXX config is not currently used
-    config = read_config(config)
-    metadata_dir = Path(metadata_dir)
-    if not metadata_dir.exists():
-        metadata_dir.mkdir()
-    notifier = Notifier(metadata_dir)
+    vmail_dir = Path(vmail_dir)
+
+    if not vmail_dir.exists():
+        logging.error("vmail dir does not exist: %r", vmail_dir)
+        return 1
+
+    notifier = Notifier(vmail_dir)
 
     class Handler(StreamRequestHandler):
         def handle(self):

--- a/chatmaild/src/chatmaild/metadata.py
+++ b/chatmaild/src/chatmaild/metadata.py
@@ -35,25 +35,23 @@ class Notifier:
         self.to_notify_queue = Queue()
 
     def get_metadata_dict(self, addr):
-        addr_path = self.vmail_dir.joinpath(addr)
-        return FileDict(addr_path / "metadata.marshalled")
+        return FileDict(self.vmail_dir / addr / "metadata.marshalled")
 
     def add_token(self, addr, token):
         with self.get_metadata_dict(addr).modify() as data:
             tokens = data.get(METADATA_TOKEN_KEY)
             if tokens is None:
-                data[METADATA_TOKEN_KEY] = tokens = []
-            if token not in tokens:
+                data[METADATA_TOKEN_KEY] = [token]
+            elif token not in tokens:
                 tokens.append(token)
 
     def remove_token(self, addr, token):
         with self.get_metadata_dict(addr).modify() as data:
-            tokens = data.get(METADATA_TOKEN_KEY)
-            if tokens:
-                try:
-                    tokens.remove(token)
-                except KeyError:
-                    pass
+            tokens = data.get(METADATA_TOKEN_KEY, [])
+            try:
+                tokens.remove(token)
+            except ValueError:
+                pass
 
     def get_tokens(self, addr):
         return self.get_metadata_dict(addr).read().get(METADATA_TOKEN_KEY, [])

--- a/chatmaild/src/chatmaild/metadata.py
+++ b/chatmaild/src/chatmaild/metadata.py
@@ -30,17 +30,22 @@ class Notifier:
 
     def set_token(self, guid, token):
         guid_path = self.metadata_dir.joinpath(guid)
-        write_path = guid_path.with_suffix(".tmp")
+        if not guid_path.exists():
+            guid_path.mkdir()
+        token_path = guid_path / "token"
+        write_path = token_path.with_suffix(".tmp")
         write_path.write_text(token)
-        write_path.rename(guid_path)
+        write_path.rename(token_path)
 
     def del_token(self, guid):
-        self.metadata_dir.joinpath(guid).unlink(missing_ok=True)
+        self.metadata_dir.joinpath(guid).joinpath("token").unlink(missing_ok=True)
 
     def get_token(self, guid):
         guid_path = self.metadata_dir / guid
         if guid_path.exists():
-            return guid_path.read_text()
+            token_path = guid_path / "token"
+            if token_path.exists():
+                return token_path.read_text()
 
     def new_message_for_guid(self, guid):
         self.to_notify_queue.put(guid)

--- a/chatmaild/src/chatmaild/metadata.py
+++ b/chatmaild/src/chatmaild/metadata.py
@@ -97,7 +97,6 @@ def handle_dovecot_protocol(rfile, wfile, notifier):
 
 def handle_dovecot_request(msg, transactions, notifier):
     # see https://doc.dovecot.org/3.0/developer_manual/design/dict_protocol/
-    logging.warning("handling request: %r", msg)
     short_command = msg[0]
     parts = msg[1:].split("\t")
     if short_command == DICTPROXY_LOOKUP_CHAR:
@@ -164,7 +163,7 @@ def main():
             try:
                 handle_dovecot_protocol(self.rfile, self.wfile, notifier)
             except Exception:
-                logging.exception("Exception in the handler")
+                logging.exception("Exception in the dovecot dictproxy handler")
                 raise
 
     try:

--- a/chatmaild/src/chatmaild/metadata.py
+++ b/chatmaild/src/chatmaild/metadata.py
@@ -34,7 +34,7 @@ class Notifier:
         mbox_path = self.vmail_dir.joinpath(mbox)
         if not mbox_path.exists():
             mbox_path.mkdir()
-        metadata_dir = mbox_path / METADATA_TOKEN_KEY
+        metadata_dir = mbox_path / "metadata"
         if not metadata_dir.exists():
             metadata_dir.mkdir()
         return metadata_dir

--- a/chatmaild/src/chatmaild/metadata.py
+++ b/chatmaild/src/chatmaild/metadata.py
@@ -16,13 +16,16 @@ import requests
 from .filedict import FileDict
 
 
+DICTPROXY_HELLO_CHAR = "H"
 DICTPROXY_LOOKUP_CHAR = "L"
 DICTPROXY_ITERATE_CHAR = "I"
-DICTPROXY_SET_CHAR = "S"
 DICTPROXY_BEGIN_TRANSACTION_CHAR = "B"
+DICTPROXY_SET_CHAR = "S"
 DICTPROXY_COMMIT_TRANSACTION_CHAR = "C"
-DICTPROXY_TRANSACTION_CHARS = "SBC"
+DICTPROXY_TRANSACTION_CHARS = "BSC"
 
+# each SETMETADATA on this key appends to a list of unique device tokens
+# which only ever get removed if the upstream indicates the token is invalid
 METADATA_TOKEN_KEY = "devicetoken"
 
 
@@ -31,22 +34,20 @@ class Notifier:
         self.vmail_dir = vmail_dir
         self.to_notify_queue = Queue()
 
-    def get_metadata_dict(self, mbox):
-        mbox_path = self.vmail_dir.joinpath(mbox)
-        if not mbox_path.exists():
-            mbox_path.mkdir()
-        return FileDict(mbox_path / "metadata.marshalled")
+    def get_metadata_dict(self, addr):
+        addr_path = self.vmail_dir.joinpath(addr)
+        return FileDict(addr_path / "metadata.marshalled")
 
-    def add_token(self, mbox, token):
-        with self.get_metadata_dict(mbox).modify() as data:
+    def add_token(self, addr, token):
+        with self.get_metadata_dict(addr).modify() as data:
             tokens = data.get(METADATA_TOKEN_KEY)
             if tokens is None:
                 data[METADATA_TOKEN_KEY] = tokens = []
             if token not in tokens:
                 tokens.append(token)
 
-    def remove_token(self, mbox, token):
-        with self.get_metadata_dict(mbox).modify() as data:
+    def remove_token(self, addr, token):
+        with self.get_metadata_dict(addr).modify() as data:
             tokens = data.get(METADATA_TOKEN_KEY)
             if tokens:
                 try:
@@ -54,11 +55,11 @@ class Notifier:
                 except KeyError:
                     pass
 
-    def get_tokens(self, mbox):
-        return self.get_metadata_dict(mbox).read().get(METADATA_TOKEN_KEY, [])
+    def get_tokens(self, addr):
+        return self.get_metadata_dict(addr).read().get(METADATA_TOKEN_KEY, [])
 
-    def new_message_for_mbox(self, mbox):
-        self.to_notify_queue.put(mbox)
+    def new_message_for_addr(self, addr):
+        self.to_notify_queue.put(addr)
 
     def thread_run_loop(self):
         requests_session = requests.Session()
@@ -66,8 +67,8 @@ class Notifier:
             self.thread_run_one(requests_session)
 
     def thread_run_one(self, requests_session):
-        mbox = self.to_notify_queue.get()
-        for token in self.get_tokens(mbox):
+        addr = self.to_notify_queue.get()
+        for token in self.get_tokens(addr):
             response = requests_session.post(
                 "https://notifications.delta.chat/notify",
                 data=token,
@@ -76,13 +77,10 @@ class Notifier:
             if response.status_code == 410:
                 # 410 Gone status code
                 # means the token is no longer valid.
-                self.remove_token(mbox, token)
+                self.remove_token(addr, token)
 
 
 def handle_dovecot_protocol(rfile, wfile, notifier):
-    # HELLO message, ignored.
-    msg = rfile.readline().strip().decode()
-
     transactions = {}
     while True:
         msg = rfile.readline().strip().decode()
@@ -104,9 +102,9 @@ def handle_dovecot_request(msg, transactions, notifier):
         keyparts = parts[0].split("/")
         if keyparts[0] == "priv":
             keyname = keyparts[2]
-            mbox = parts[1]
+            addr = parts[1]
             if keyname == METADATA_TOKEN_KEY:
-                res = " ".join(notifier.get_tokens(mbox))
+                res = " ".join(notifier.get_tokens(addr))
                 return f"O{res}\n"
         logging.warning("lookup ignored: %r", msg)
         return "N\n"
@@ -114,29 +112,35 @@ def handle_dovecot_request(msg, transactions, notifier):
         # Empty line means ITER_FINISHED.
         # If we don't return empty line Dovecot will timeout.
         return "\n"
+    elif short_command == DICTPROXY_HELLO_CHAR:
+        return  # no version checking
 
     if short_command not in (DICTPROXY_TRANSACTION_CHARS):
+        logging.warning("unknown dictproxy request: %r", msg)
         return
 
     transaction_id = parts[0]
 
     if short_command == DICTPROXY_BEGIN_TRANSACTION_CHAR:
-        mbox = parts[1]
-        transactions[transaction_id] = dict(mbox=mbox, res="O\n")
+        addr = parts[1]
+        transactions[transaction_id] = dict(addr=addr, res="O\n")
     elif short_command == DICTPROXY_COMMIT_TRANSACTION_CHAR:
-        # returns whether it failed or succeeded.
+        # each set devicetoken operation persists directly
+        # and does not wait until a "commit" comes
+        # because our dovecot config does not involve
+        # multiple set-operations in a single commit
         return transactions.pop(transaction_id)["res"]
     elif short_command == DICTPROXY_SET_CHAR:
         # For documentation on key structure see
-        # <https://github.com/dovecot/core/blob/5e7965632395793d9355eb906b173bf28d2a10ca/src/lib-storage/mailbox-attribute.h>
+        # https://github.com/dovecot/core/blob/main/src/lib-storage/mailbox-attribute.h
 
         keyname = parts[1].split("/")
         value = parts[2] if len(parts) > 2 else ""
-        mbox = transactions[transaction_id]["mbox"]
+        addr = transactions[transaction_id]["addr"]
         if keyname[0] == "priv" and keyname[2] == METADATA_TOKEN_KEY:
-            notifier.add_token(mbox, value)
+            notifier.add_token(addr, value)
         elif keyname[0] == "priv" and keyname[2] == "messagenew":
-            notifier.new_message_for_mbox(mbox)
+            notifier.new_message_for_addr(addr)
         else:
             # Transaction failed.
             transactions[transaction_id]["res"] = "F\n"

--- a/chatmaild/src/chatmaild/metadata.py
+++ b/chatmaild/src/chatmaild/metadata.py
@@ -35,7 +35,7 @@ class Notifier:
         self.to_notify_queue = Queue()
 
     def get_metadata_dict(self, addr):
-        return FileDict(self.vmail_dir / addr / "metadata.marshalled")
+        return FileDict(self.vmail_dir / addr / "metadata.json")
 
     def add_token(self, addr, token):
         with self.get_metadata_dict(addr).modify() as data:

--- a/chatmaild/src/chatmaild/tests/test_filedict.py
+++ b/chatmaild/src/chatmaild/tests/test_filedict.py
@@ -1,0 +1,24 @@
+from chatmaild.filedict import FileDict
+
+
+def test_basic(tmp_path):
+    fdict = FileDict(tmp_path.joinpath("metadata"))
+    assert fdict.read() == {}
+    with fdict.modify() as d:
+        d["devicetoken"] = [1, 2, 3]
+        d["456"] = 4.2
+    new = fdict.read()
+    assert new["devicetoken"] == [1, 2, 3]
+    assert new["456"] == 4.2
+
+
+def test_dying_lock(tmp_path, caplog):
+    fdict1 = FileDict(tmp_path.joinpath("metadata"))
+    fdict2 = FileDict(tmp_path.joinpath("metadata"), timeout=0.1)
+    with fdict1.modify() as d:
+        with fdict2.modify() as d2:
+            d2["1"] = "2"
+        assert "could not obtain" in caplog.records[0].msg
+        d["1"] = "3"
+    assert fdict1.read()["1"] == "3"
+    assert fdict2.read()["1"] == "3"

--- a/chatmaild/src/chatmaild/tests/test_filedict.py
+++ b/chatmaild/src/chatmaild/tests/test_filedict.py
@@ -12,18 +12,6 @@ def test_basic(tmp_path):
     assert new["456"] == 4.2
 
 
-def test_dying_lock(tmp_path, caplog):
-    fdict1 = FileDict(tmp_path.joinpath("metadata"))
-    fdict2 = FileDict(tmp_path.joinpath("metadata"), timeout=0.1)
-    with fdict1.modify() as d:
-        with fdict2.modify() as d2:
-            d2["1"] = "2"
-        assert "could not obtain" in caplog.records[0].msg
-        d["1"] = "3"
-    assert fdict1.read()["1"] == "3"
-    assert fdict2.read()["1"] == "3"
-
-
 def test_bad_marshal_file(tmp_path, caplog):
     fdict1 = FileDict(tmp_path.joinpath("metadata"))
     fdict1.path.write_bytes(b"l12k3l12k3l")

--- a/chatmaild/src/chatmaild/tests/test_filedict.py
+++ b/chatmaild/src/chatmaild/tests/test_filedict.py
@@ -22,3 +22,10 @@ def test_dying_lock(tmp_path, caplog):
         d["1"] = "3"
     assert fdict1.read()["1"] == "3"
     assert fdict2.read()["1"] == "3"
+
+
+def test_bad_marshal_file(tmp_path, caplog):
+    fdict1 = FileDict(tmp_path.joinpath("metadata"))
+    fdict1.path.write_bytes(b"l12k3l12k3l")
+    assert fdict1.read() == {}
+    assert "corrupt" in caplog.records[0].msg

--- a/chatmaild/src/chatmaild/tests/test_metadata.py
+++ b/chatmaild/src/chatmaild/tests/test_metadata.py
@@ -31,6 +31,11 @@ def test_notifier_persistence(tmp_path):
     assert notifier1.get_token("guid00") is None
 
 
+def test_notifier_delete_without_set(notifier):
+    notifier.del_token("guid00")
+    assert not notifier.get_token("guid00")
+
+
 def test_handle_dovecot_request_lookup_fails(notifier):
     res = handle_dovecot_request("Lpriv/123/chatmail", {}, notifier)
     assert res == "N\n"

--- a/chatmaild/src/chatmaild/tests/test_metadata.py
+++ b/chatmaild/src/chatmaild/tests/test_metadata.py
@@ -5,7 +5,6 @@ from chatmaild.metadata import (
     handle_dovecot_request,
     handle_dovecot_protocol,
     Notifier,
-    PersistentDict,
 )
 
 
@@ -30,12 +29,12 @@ def test_notifier_persistence(tmp_path):
     notifier1.add_token("user3@example.org", "456")
     assert notifier2.get_tokens("user1@example.org") == ["01234"]
     assert notifier2.get_tokens("user3@example.org") == ["456"]
-    notifier2.del_token("user1@example.org", "01234")
+    notifier2.remove_token("user1@example.org", "01234")
     assert not notifier1.get_tokens("user1@example.org")
 
 
 def test_notifier_delete_without_set(notifier):
-    notifier.del_token("user@example.org", "123")
+    notifier.remove_token("user@example.org", "123")
     assert not notifier.get_tokens("user@example.org")
 
 
@@ -217,28 +216,3 @@ def test_notifier_thread_run_gone_removes_token(notifier):
     url, data, timeout = requests[1]
     assert data == "45678"
     assert notifier.get_tokens("user@example.org") == ["45678"]
-
-
-class TestPersistentDict:
-    @pytest.fixture
-    def store(self, tmp_path):
-        return PersistentDict(tmp_path.joinpath("metadata"))
-
-    def test_basic(self, store):
-        assert store.get() == {}
-        with store.modify() as d:
-            d["devicetoken"] = [1, 2, 3]
-            d["456"] = 4.2
-        new = store.get()
-        assert new["devicetoken"] == [1, 2, 3]
-        assert new["456"] == 4.2
-
-    def test_dying_lock(self, tmp_path, caplog):
-        store1 = PersistentDict(tmp_path.joinpath("metadata"))
-        store2 = PersistentDict(tmp_path.joinpath("metadata"), timeout=0.1)
-        with store1.modify() as d:
-            with store2.modify() as d2:
-                d2["1"] = "2"
-            assert "could not obtain" in caplog.records[0].msg
-            d["1"] = "3"
-        assert store1.get()["1"] == "3"

--- a/chatmaild/src/chatmaild/tests/test_metadata.py
+++ b/chatmaild/src/chatmaild/tests/test_metadata.py
@@ -40,6 +40,13 @@ def test_notifier_persistence(tmp_path, testaddr, testaddr2):
     assert notifier1.get_tokens(testaddr2) == ["456"]
 
 
+def test_remove_nonexisting(tmp_path, testaddr):
+    notifier1 = Notifier(tmp_path)
+    notifier1.add_token(testaddr, "123")
+    notifier1.remove_token(testaddr, "1l23k1l2k3")
+    assert notifier1.get_tokens(testaddr) == ["123"]
+
+
 def test_notifier_delete_without_set(notifier, testaddr):
     notifier.remove_token(testaddr, "123")
     assert not notifier.get_tokens(testaddr)

--- a/chatmaild/src/chatmaild/tests/test_metadata.py
+++ b/chatmaild/src/chatmaild/tests/test_metadata.py
@@ -84,10 +84,10 @@ def test_handle_dovecot_request_happy_path(notifier, testaddr):
     assert handle_dovecot_request(f"B{tx2}\t{testaddr}", transactions, notifier) is None
     msg = f"S{tx2}\tpriv/guid00/messagenew"
     assert handle_dovecot_request(msg, transactions, notifier) is None
-    assert notifier.to_notify_queue.get() == testaddr
-    assert notifier.to_notify_queue.qsize() == 0
+    assert notifier.message_arrived_event.is_set()
     assert handle_dovecot_request(f"C{tx2}", transactions, notifier) == "O\n"
     assert not transactions
+    assert notifier.notification_dir.joinpath(testaddr).exists()
 
 
 def test_handle_dovecot_protocol_set_devicetoken(notifier):
@@ -159,8 +159,8 @@ def test_handle_dovecot_protocol_messagenew(notifier):
     wfile = io.BytesIO()
     handle_dovecot_protocol(rfile, wfile, notifier)
     assert wfile.getvalue() == b"O\n"
-    assert notifier.to_notify_queue.get() == "user@example.org"
-    assert notifier.to_notify_queue.qsize() == 0
+    assert notifier.message_arrived_event.is_set()
+    assert notifier.notification_dir.joinpath("user@example.org").exists()
 
 
 def test_notifier_thread_run(notifier, testaddr):

--- a/chatmaild/src/chatmaild/tests/test_metadata.py
+++ b/chatmaild/src/chatmaild/tests/test_metadata.py
@@ -22,20 +22,20 @@ def test_notifier_persistence(tmp_path):
 
     notifier1 = Notifier(vmail_dir)
     notifier2 = Notifier(vmail_dir)
-    assert notifier1.get_token("user1@example.org") is None
-    assert notifier2.get_token("user1@example.org") is None
+    assert not notifier1.get_tokens("user1@example.org")
+    assert not notifier2.get_tokens("user1@example.org")
 
     notifier1.set_token("user1@example.org", "01234")
     notifier1.set_token("user3@example.org", "456")
-    assert notifier2.get_token("user1@example.org") == "01234"
-    assert notifier2.get_token("user3@example.org") == "456"
-    notifier2.del_token("user1@example.org")
-    assert notifier1.get_token("user1@example.org") is None
+    assert notifier2.get_tokens("user1@example.org") == ["01234"]
+    assert notifier2.get_tokens("user3@example.org") == ["456"]
+    notifier2.del_token("user1@example.org", "01234")
+    assert not notifier1.get_tokens("user1@example.org")
 
 
 def test_notifier_delete_without_set(notifier):
-    notifier.del_token("user@example.org")
-    assert not notifier.get_token("user@example.org")
+    notifier.del_token("user@example.org", "123")
+    assert not notifier.get_tokens("user@example.org")
 
 
 def test_handle_dovecot_request_lookup_fails(notifier):
@@ -50,20 +50,20 @@ def test_handle_dovecot_request_happy_path(notifier):
     tx = "1111"
     msg = f"B{tx}\tuser@example.org"
     res = handle_dovecot_request(msg, transactions, notifier)
-    assert not res and notifier.get_token("user@example.org") is None
+    assert not res and not notifier.get_tokens("user@example.org")
     assert transactions == {tx: dict(mbox="user@example.org", res="O\n")}
 
     msg = f"S{tx}\tpriv/guid00/devicetoken\t01234"
     res = handle_dovecot_request(msg, transactions, notifier)
     assert not res
     assert len(transactions) == 1
-    assert notifier.get_token("user@example.org") == "01234"
+    assert notifier.get_tokens("user@example.org") == ["01234"]
 
     msg = f"C{tx}"
     res = handle_dovecot_request(msg, transactions, notifier)
     assert res == "O\n"
     assert len(transactions) == 0
-    assert notifier.get_token("user@example.org") == "01234"
+    assert notifier.get_tokens("user@example.org") == ["01234"]
 
     # trigger notification for incoming message
     assert (
@@ -92,7 +92,7 @@ def test_handle_dovecot_protocol_set_devicetoken(notifier):
     wfile = io.BytesIO()
     handle_dovecot_protocol(rfile, wfile, notifier)
     assert wfile.getvalue() == b"O\n"
-    assert notifier.get_token("user@example.org") == "01234"
+    assert notifier.get_tokens("user@example.org") == ["01234"]
 
 
 def test_handle_dovecot_protocol_set_get_devicetoken(notifier):
@@ -108,7 +108,7 @@ def test_handle_dovecot_protocol_set_get_devicetoken(notifier):
     )
     wfile = io.BytesIO()
     handle_dovecot_protocol(rfile, wfile, notifier)
-    assert notifier.get_token("user@example.org") == "01234"
+    assert notifier.get_tokens("user@example.org") == ["01234"]
     assert wfile.getvalue() == b"O\n"
 
     rfile = io.BytesIO(
@@ -168,7 +168,29 @@ def test_notifier_thread_run(notifier):
     notifier.thread_run_one(ReqMock())
     url, data, timeout = requests[0]
     assert data == "01234"
-    assert notifier.get_token("user@example.org") == "01234"
+    assert notifier.get_tokens("user@example.org") == ["01234"]
+
+
+def test_multi_device_notifier(notifier):
+    requests = []
+
+    class ReqMock:
+        def post(self, url, data, timeout):
+            requests.append((url, data, timeout))
+
+            class Result:
+                status_code = 200
+
+            return Result()
+
+    notifier.set_token("user@example.org", "01234")
+    notifier.set_token("user@example.org", "56789")
+    notifier.new_message_for_mbox("user@example.org")
+    notifier.thread_run_one(ReqMock())
+    url, data, timeout = requests[0]
+    assert data == "01234"
+    url, data, timeout = requests[1]
+    assert data == "56789"
 
 
 def test_notifier_thread_run_gone_removes_token(notifier):
@@ -179,14 +201,17 @@ def test_notifier_thread_run_gone_removes_token(notifier):
             requests.append((url, data, timeout))
 
             class Result:
-                status_code = 410
+                status_code = 410 if data == "01234" else 200
 
             return Result()
 
     notifier.set_token("user@example.org", "01234")
     notifier.new_message_for_mbox("user@example.org")
-    assert notifier.get_token("user@example.org") == "01234"
+    assert notifier.get_tokens("user@example.org") == ["01234"]
+    notifier.set_token("user@example.org", "45678")
     notifier.thread_run_one(ReqMock())
     url, data, timeout = requests[0]
     assert data == "01234"
-    assert notifier.get_token("user@example.org") is None
+    url, data, timeout = requests[1]
+    assert data == "45678"
+    assert notifier.get_tokens("user@example.org") == ["45678"]

--- a/chatmaild/src/chatmaild/tests/test_metadata.py
+++ b/chatmaild/src/chatmaild/tests/test_metadata.py
@@ -26,8 +26,8 @@ def test_notifier_persistence(tmp_path):
     assert not notifier1.get_tokens("user1@example.org")
     assert not notifier2.get_tokens("user1@example.org")
 
-    notifier1.set_token("user1@example.org", "01234")
-    notifier1.set_token("user3@example.org", "456")
+    notifier1.add_token("user1@example.org", "01234")
+    notifier1.add_token("user3@example.org", "456")
     assert notifier2.get_tokens("user1@example.org") == ["01234"]
     assert notifier2.get_tokens("user3@example.org") == ["456"]
     notifier2.del_token("user1@example.org", "01234")
@@ -164,7 +164,7 @@ def test_notifier_thread_run(notifier):
 
             return Result()
 
-    notifier.set_token("user@example.org", "01234")
+    notifier.add_token("user@example.org", "01234")
     notifier.new_message_for_mbox("user@example.org")
     notifier.thread_run_one(ReqMock())
     url, data, timeout = requests[0]
@@ -184,14 +184,15 @@ def test_multi_device_notifier(notifier):
 
             return Result()
 
-    notifier.set_token("user@example.org", "01234")
-    notifier.set_token("user@example.org", "56789")
+    notifier.add_token("user@example.org", "01234")
+    notifier.add_token("user@example.org", "56789")
     notifier.new_message_for_mbox("user@example.org")
     notifier.thread_run_one(ReqMock())
     url, data, timeout = requests[0]
     assert data == "01234"
     url, data, timeout = requests[1]
     assert data == "56789"
+    assert notifier.get_tokens("user@example.org") == ["01234", "56789"]
 
 
 def test_notifier_thread_run_gone_removes_token(notifier):
@@ -206,10 +207,10 @@ def test_notifier_thread_run_gone_removes_token(notifier):
 
             return Result()
 
-    notifier.set_token("user@example.org", "01234")
+    notifier.add_token("user@example.org", "01234")
     notifier.new_message_for_mbox("user@example.org")
     assert notifier.get_tokens("user@example.org") == ["01234"]
-    notifier.set_token("user@example.org", "45678")
+    notifier.add_token("user@example.org", "45678")
     notifier.thread_run_one(ReqMock())
     url, data, timeout = requests[0]
     assert data == "01234"

--- a/chatmaild/src/chatmaild/tests/test_metadata.py
+++ b/chatmaild/src/chatmaild/tests/test_metadata.py
@@ -10,30 +10,32 @@ from chatmaild.metadata import (
 
 @pytest.fixture
 def notifier(tmp_path):
-    metadata_dir = tmp_path.joinpath("metadata")
-    metadata_dir.mkdir()
-    return Notifier(metadata_dir)
+    vmail_dir = tmp_path.joinpath("vmaildir")
+    vmail_dir.mkdir()
+    return Notifier(vmail_dir)
 
 
 def test_notifier_persistence(tmp_path):
-    metadata_dir = tmp_path.joinpath("metadata")
-    metadata_dir.mkdir()
-    notifier1 = Notifier(metadata_dir)
-    notifier2 = Notifier(metadata_dir)
-    assert notifier1.get_token(guid="guid00") is None
-    assert notifier2.get_token(guid="guid00") is None
+    vmail_dir = tmp_path
+    vmail_dir.joinpath("user1@example.org").mkdir()
+    vmail_dir.joinpath("user3@example.org").mkdir()
 
-    notifier1.set_token("guid00", "01234")
-    notifier1.set_token("guid03", "456")
-    assert notifier2.get_token("guid00") == "01234"
-    assert notifier2.get_token("guid03") == "456"
-    notifier2.del_token("guid00")
-    assert notifier1.get_token("guid00") is None
+    notifier1 = Notifier(vmail_dir)
+    notifier2 = Notifier(vmail_dir)
+    assert notifier1.get_token("user1@example.org") is None
+    assert notifier2.get_token("user1@example.org") is None
+
+    notifier1.set_token("user1@example.org", "01234")
+    notifier1.set_token("user3@example.org", "456")
+    assert notifier2.get_token("user1@example.org") == "01234"
+    assert notifier2.get_token("user3@example.org") == "456"
+    notifier2.del_token("user1@example.org")
+    assert notifier1.get_token("user1@example.org") is None
 
 
 def test_notifier_delete_without_set(notifier):
-    notifier.del_token("guid00")
-    assert not notifier.get_token("guid00")
+    notifier.del_token("user@example.org")
+    assert not notifier.get_token("user@example.org")
 
 
 def test_handle_dovecot_request_lookup_fails(notifier):

--- a/cmdeploy/pyproject.toml
+++ b/cmdeploy/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
   "black",
   "pytest",
   "pytest-xdist", 
+  "imap_tools",
 ]
 
 [project.scripts]

--- a/cmdeploy/src/cmdeploy/__init__.py
+++ b/cmdeploy/src/cmdeploy/__init__.py
@@ -108,6 +108,7 @@ def _install_remote_venv_with_chatmaild(config) -> None:
             execpath=f"{remote_venv_dir}/bin/{fn}",
             config_path=remote_chatmail_inipath,
             remote_venv_dir=remote_venv_dir,
+            mail_domain=config.mail_domain,
         )
         source_path = importlib.resources.files("chatmaild").joinpath(f"{fn}.service.f")
         content = source_path.read_text().format(**params).encode()

--- a/cmdeploy/src/cmdeploy/tests/online/test_2_deltachat.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_2_deltachat.py
@@ -24,14 +24,27 @@ class TestMetadataTokens:
     def test_set_get_metadata(self, imap_mailbox):
         "set and get metadata token for an account"
         client = imap_mailbox.client
-        client.send(b'a01 SETMETADATA INBOX (/private/devicetoken "l1kj23lk123" )\n')
+        client.send(b'a01 SETMETADATA INBOX (/private/devicetoken "1111" )\n')
         res = client.readline()
         assert b"OK Setmetadata completed" in res
+
         client.send(b"a02 GETMETADATA INBOX /private/devicetoken\n")
         res = client.readline()
         assert res[:1] == b"*"
-        res = client.readline().strip()[:-1]
-        assert res == b"l1kj23lk123"
+        res = client.readline().strip().rstrip(b")")
+        assert res == b"1111"
+        assert b"Getmetadata completed" in client.readline()
+
+        client.send(b'a01 SETMETADATA INBOX (/private/devicetoken "2222" )\n')
+        res = client.readline()
+        assert b"OK Setmetadata completed" in res
+
+        client.send(b"a02 GETMETADATA INBOX /private/devicetoken\n")
+        res = client.readline()
+        assert res[:1] == b"*"
+        res = client.readline().strip().rstrip(b")")
+        assert res == b"1111 2222"
+        assert b"Getmetadata completed" in client.readline()
 
 
 class TestEndToEndDeltaChat:


### PR DESCRIPTION
supersedes #243 

As discussed [here](https://github.com/deltachat/chatmail/pull/243#issuecomment-2022442764) it is possible to know the mailbox-dir for metadata get/set requests so this PR sets/gets devicetokens accordingly. 
This means that a mailbox-dir (the inbox folder of a user basically) contains also the metadata, now in the "metadata.marshalled" file in the inbox folder. 
The data is persisted using the builtin "marshal" module and guarded by an os-level file lock. 

The PR also adds both local as well as online tests, and adds support for GETMETADATA. 