### PR TITLE
CI: fix rsync statements

### DIFF
--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -48,6 +48,7 @@ jobs:
           ssh -o StrictHostKeyChecking=accept-new -v root@staging.testrun.org id -u
           rsync -avz acme/ root@staging.testrun.org:/var/lib/acme || true
           rsync -avz dkimkeys/ root@staging.testrun.org:/etc/dkimkeys || true
+          ssh -o StrictHostKeyChecking=accept-new -v root@staging.testrun.org chown root:root -R /var/lib/acme
 
       - name: run formatting checks 
         run: cmdeploy fmt -v 

--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -46,8 +46,8 @@ jobs:
           rm ~/.ssh/known_hosts
           while ! ssh -o ConnectTimeout=180 -o StrictHostKeyChecking=accept-new -v root@staging.testrun.org id -u ; do sleep 1 ; done
           ssh -o StrictHostKeyChecking=accept-new -v root@staging.testrun.org id -u
-          rsync -avz acme root@staging.testrun.org:/var/lib/ || true
-          rsync -avz dkimkeys root@staging.testrun.org:/etc/ || true
+          rsync -avz acme/ root@staging.testrun.org:/var/lib/acme || true
+          rsync -avz dkimkeys/ root@staging.testrun.org:/etc/dkimkeys || true
 
       - name: run formatting checks 
         run: cmdeploy fmt -v 


### PR DESCRIPTION
The CI doesn't seem to restore Let's Encrypt and DKIM state properly, so it ran into Let's Encrypt rate limit: https://github.com/deltachat/chatmail/actions/runs/8477304659/job/23228081309?pr=261