### PR TITLE
Keep notification ordering and back off failed notification attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Install dig on the server to resolve DNS records
   ([#267](https://github.com/deltachat/chatmail/pull/267))
 
+- preserve notification order and exponentially backoff with 
+  retries for tokens where we didn't get a successful return
+  ([#265](https://github.com/deltachat/chatmail/pull/263))
+
 - Run chatmail-metadata and doveauth as vmail
   ([#261](https://github.com/deltachat/chatmail/pull/261))
 

--- a/chatmaild/src/chatmaild/metadata.py
+++ b/chatmaild/src/chatmaild/metadata.py
@@ -60,11 +60,11 @@ class Notifier:
             except ValueError:
                 pass
 
-    def get_tokens(self, addr):
+    def get_tokens_for_addr(self, addr):
         return self.get_metadata_dict(addr).read().get(METADATA_TOKEN_KEY, [])
 
     def new_message_for_addr(self, addr):
-        for token in self.get_tokens(addr):
+        for token in self.get_tokens_for_addr(addr):
             self.notification_dir.joinpath(token).write_text(addr)
             self.add_token_for_retry(token)
 
@@ -158,7 +158,7 @@ def handle_dovecot_request(msg, transactions, notifier):
             keyname = keyparts[2]
             addr = parts[1]
             if keyname == METADATA_TOKEN_KEY:
-                res = " ".join(notifier.get_tokens(addr))
+                res = " ".join(notifier.get_tokens_for_addr(addr))
                 return f"O{res}\n"
         logging.warning("lookup ignored: %r", msg)
         return "N\n"
@@ -192,7 +192,7 @@ def handle_dovecot_request(msg, transactions, notifier):
         value = parts[2] if len(parts) > 2 else ""
         addr = transactions[transaction_id]["addr"]
         if keyname[0] == "priv" and keyname[2] == METADATA_TOKEN_KEY:
-            notifier.add_token(addr, value)
+            notifier.add_token_to_addr(addr, value)
         elif keyname[0] == "priv" and keyname[2] == "messagenew":
             notifier.new_message_for_addr(addr)
         else:

--- a/chatmaild/src/chatmaild/metadata.py
+++ b/chatmaild/src/chatmaild/metadata.py
@@ -1,7 +1,4 @@
-import time
 from pathlib import Path
-from threading import Thread
-from queue import PriorityQueue
 from socketserver import (
     UnixStreamServer,
     StreamRequestHandler,
@@ -10,9 +7,9 @@ from socketserver import (
 import sys
 import logging
 import os
-import requests
 
 from .filedict import FileDict
+from .notifier import Notifier
 
 
 DICTPROXY_HELLO_CHAR = "H"
@@ -23,146 +20,51 @@ DICTPROXY_SET_CHAR = "S"
 DICTPROXY_COMMIT_TRANSACTION_CHAR = "C"
 DICTPROXY_TRANSACTION_CHARS = "BSC"
 
-# each SETMETADATA on this key appends to a list of unique device tokens
-# which only ever get removed if the upstream indicates the token is invalid
-METADATA_TOKEN_KEY = "devicetoken"
 
-
-class Notifier:
-    URL = "https://notifications.delta.chat/notify"
-    CONNECTION_TIMEOUT = 60.0       # seconds until http-request is given up
-    NOTIFICATION_RETRY_DELAY = 8.0  # seconds with exponential backoff
-    MAX_NUMBER_OF_TRIES = 6
-    # exponential backoff means we try for 8^5 seconds, approximately 10 hours
+class Metadata:
+    # each SETMETADATA on this key appends to a list of unique device tokens
+    # which only ever get removed if the upstream indicates the token is invalid
+    DEVICETOKEN_KEY = "devicetoken"
 
     def __init__(self, vmail_dir):
         self.vmail_dir = vmail_dir
-        self.notification_dir = vmail_dir / "pending_notifications"
-        if not self.notification_dir.exists():
-            self.notification_dir.mkdir()
-        self.retry_queues = [PriorityQueue() for _ in range(self.MAX_NUMBER_OF_TRIES)]
 
     def get_metadata_dict(self, addr):
         return FileDict(self.vmail_dir / addr / "metadata.json")
 
     def add_token_to_addr(self, addr, token):
         with self.get_metadata_dict(addr).modify() as data:
-            tokens = data.get(METADATA_TOKEN_KEY)
+            tokens = data.get(self.DEVICETOKEN_KEY)
             if tokens is None:
-                data[METADATA_TOKEN_KEY] = [token]
+                data[self.DEVICETOKEN_KEY] = [token]
             elif token not in tokens:
                 tokens.append(token)
 
     def remove_token_from_addr(self, addr, token):
         with self.get_metadata_dict(addr).modify() as data:
-            tokens = data.get(METADATA_TOKEN_KEY, [])
+            tokens = data.get(self.DEVICETOKEN_KEY, [])
             if token in tokens:
                 tokens.remove(token)
 
     def get_tokens_for_addr(self, addr):
-        return self.get_metadata_dict(addr).read().get(METADATA_TOKEN_KEY, [])
-
-    def new_message_for_addr(self, addr):
-        for token in self.get_tokens_for_addr(addr):
-            self.notification_dir.joinpath(token).write_text(addr)
-            self.add_token_for_retry(token)
-
-    def add_token_for_retry(self, token, retry_num=0):
-        if retry_num >= self.MAX_NUMBER_OF_TRIES:
-            return False
-
-        when = time.time()
-        if retry_num > 0:
-            # backup exponentially with number of retries
-            when += pow(self.NOTIFICATION_RETRY_DELAY, retry_num)
-        self.retry_queues[retry_num].put((when, token))
-        return True
-
-    def requeue_persistent_pending_tokens(self):
-        for token_path in self.notification_dir.iterdir():
-            self.add_token_for_retry(token_path.name)
-
-    def start_notification_threads(self):
-        self.requeue_persistent_pending_tokens()
-        threads = {}
-        for retry_num in range(len(self.retry_queues)):
-            num_threads = {0: 4}.get(retry_num, 2)
-            threads[retry_num] = []
-            for _ in range(num_threads):
-                threads[retry_num].append(NotifyThread(self, retry_num))
-                threads[retry_num][-1].start()
-        return threads
+        mdict = self.get_metadata_dict(addr).read()
+        return mdict.get(self.DEVICETOKEN_KEY, [])
 
 
-class NotifyThread(Thread):
-    def __init__(self, notifier, retry_num):
-        super().__init__(daemon=True)
-        self.notifier = notifier
-        self.retry_num = retry_num
-
-    def stop(self):
-        self.notifier.retry_queues[self.retry_num].put((None, None))
-
-    def run(self):
-        requests_session = requests.Session()
-        while self.retry_one(requests_session):
-            pass
-
-    def retry_one(self, requests_session, sleep=time.sleep):
-        # takes the next token from the per-retry-number PriorityQueue
-        # which is ordered by "when" (as set by add_token_for_retry()).
-        # If the request to notification server fails the token is
-        # queued to the next retry-number's PriorityQueue
-        # until it finally is dropped if MAX_NUMBER_OF_TRIES is exceeded
-        when, token = self.notifier.retry_queues[self.retry_num].get()
-        if when is None:
-            return False
-        wait_time = when - time.time()
-        if wait_time > 0:
-            sleep(wait_time)
-        self.perform_request_to_notification_server(requests_session, token)
-        return True
-
-    def perform_request_to_notification_server(self, requests_session, token):
-        token_path = self.notifier.notification_dir.joinpath(token)
-        try:
-            timeout = self.notifier.CONNECTION_TIMEOUT
-            res = requests_session.post(self.notifier.URL, data=token, timeout=timeout)
-        except requests.exceptions.RequestException as e:
-            res = e
-        else:
-            if res.status_code in (200, 410):
-                if res.status_code == 410:
-                    # 410 Gone: means the token is no longer valid.
-                    try:
-                        addr = token_path.read_text()
-                    except FileNotFoundError:
-                        logging.warning("no address for token %r:", token)
-                        return
-                    self.notifier.remove_token_from_addr(addr, token)
-                token_path.unlink(missing_ok=True)
-                return
-
-        logging.warning("Notification request failed: %r", res)
-        if not self.notifier.add_token_for_retry(token, retry_num=self.retry_num + 1):
-            token_path.unlink(missing_ok=True)
-            logging.warning("dropping token after %d tries: %r", self.retry_num, token)
-
-
-def handle_dovecot_protocol(rfile, wfile, notifier):
+def handle_dovecot_protocol(rfile, wfile, notifier, metadata):
     transactions = {}
     while True:
         msg = rfile.readline().strip().decode()
         if not msg:
             break
 
-        res = handle_dovecot_request(msg, transactions, notifier)
+        res = handle_dovecot_request(msg, transactions, notifier, metadata)
         if res:
             wfile.write(res.encode("ascii"))
             wfile.flush()
 
 
-def handle_dovecot_request(msg, transactions, notifier):
+def handle_dovecot_request(msg, transactions, notifier, metadata):
     # see https://doc.dovecot.org/3.0/developer_manual/design/dict_protocol/
     short_command = msg[0]
     parts = msg[1:].split("\t")
@@ -172,8 +74,8 @@ def handle_dovecot_request(msg, transactions, notifier):
         if keyparts[0] == "priv":
             keyname = keyparts[2]
             addr = parts[1]
-            if keyname == METADATA_TOKEN_KEY:
-                res = " ".join(notifier.get_tokens_for_addr(addr))
+            if keyname == metadata.DEVICETOKEN_KEY:
+                res = " ".join(metadata.get_tokens_for_addr(addr))
                 return f"O{res}\n"
         logging.warning("lookup ignored: %r", msg)
         return "N\n"
@@ -206,10 +108,10 @@ def handle_dovecot_request(msg, transactions, notifier):
         keyname = parts[1].split("/")
         value = parts[2] if len(parts) > 2 else ""
         addr = transactions[transaction_id]["addr"]
-        if keyname[0] == "priv" and keyname[2] == METADATA_TOKEN_KEY:
-            notifier.add_token_to_addr(addr, value)
+        if keyname[0] == "priv" and keyname[2] == metadata.DEVICETOKEN_KEY:
+            metadata.add_token_to_addr(addr, value)
         elif keyname[0] == "priv" and keyname[2] == "messagenew":
-            notifier.new_message_for_addr(addr)
+            notifier.new_message_for_addr(addr, metadata)
         else:
             # Transaction failed.
             transactions[transaction_id]["res"] = "F\n"
@@ -228,13 +130,17 @@ def main():
         logging.error("vmail dir does not exist: %r", vmail_dir)
         return 1
 
-    notifier = Notifier(vmail_dir)
-    notifier.start_notification_threads()
+    notification_dir = vmail_dir / "pending_notifications"
+    if not notification_dir.exists():
+        notification_dir.mkdir()
+    metadata = Metadata(vmail_dir)
+    notifier = Notifier(metadata, notification_dir)
+    notifier.start_notification_threads(metadata.remove_token_from_addr)
 
     class Handler(StreamRequestHandler):
         def handle(self):
             try:
-                handle_dovecot_protocol(self.rfile, self.wfile, notifier)
+                handle_dovecot_protocol(self.rfile, self.wfile, notifier, metadata)
             except Exception:
                 logging.exception("Exception in the dovecot dictproxy handler")
                 raise

--- a/chatmaild/src/chatmaild/metadata.py
+++ b/chatmaild/src/chatmaild/metadata.py
@@ -90,12 +90,12 @@ class Notifier:
         while True:
             self.thread_retry_one(requests_session, numtries)
 
-    def thread_retry_one(self, requests_session, numtries):
+    def thread_retry_one(self, requests_session, numtries, sleepfunc=time.sleep):
         retry_queue = self.retry_queues[numtries]
         when, token = retry_queue.get()
         wait_time = when - time.time()
         if wait_time > 0:
-            time.sleep(wait_time)
+            sleepfunc(wait_time)
         self.notify_one(requests_session, token, numtries)
 
     def notify_one(self, requests_session, token, numtries=0):

--- a/chatmaild/src/chatmaild/metadata.py
+++ b/chatmaild/src/chatmaild/metadata.py
@@ -134,7 +134,7 @@ def main():
     if not notification_dir.exists():
         notification_dir.mkdir()
     metadata = Metadata(vmail_dir)
-    notifier = Notifier(metadata, notification_dir)
+    notifier = Notifier(notification_dir)
     notifier.start_notification_threads(metadata.remove_token_from_addr)
 
     class Handler(StreamRequestHandler):

--- a/chatmaild/src/chatmaild/metadata.py
+++ b/chatmaild/src/chatmaild/metadata.py
@@ -34,10 +34,8 @@ class Metadata:
 
     def add_token_to_addr(self, addr, token):
         with self.get_metadata_dict(addr).modify() as data:
-            tokens = data.get(self.DEVICETOKEN_KEY)
-            if tokens is None:
-                data[self.DEVICETOKEN_KEY] = [token]
-            elif token not in tokens:
+            tokens = data.setdefault(self.DEVICETOKEN_KEY, [])
+            if token not in tokens:
                 tokens.append(token)
 
     def remove_token_from_addr(self, addr, token):
@@ -130,8 +128,7 @@ def main():
         return 1
 
     notification_dir = vmail_dir / "pending_notifications"
-    if not notification_dir.exists():
-        notification_dir.mkdir()
+    notification_dir.mkdir(exist_ok=True)
     metadata = Metadata(vmail_dir)
     notifier = Notifier(notification_dir)
     notifier.start_notification_threads(metadata.remove_token_from_addr)

--- a/chatmaild/src/chatmaild/metadata.py
+++ b/chatmaild/src/chatmaild/metadata.py
@@ -125,7 +125,6 @@ def main():
     socket, vmail_dir = sys.argv[1:]
 
     vmail_dir = Path(vmail_dir)
-
     if not vmail_dir.exists():
         logging.error("vmail dir does not exist: %r", vmail_dir)
         return 1

--- a/chatmaild/src/chatmaild/metadata.py
+++ b/chatmaild/src/chatmaild/metadata.py
@@ -131,7 +131,7 @@ class Notifier:
         logging.warning("Notification request failed: %r", response)
         if not self.add_token_for_retry(token, numtries=numtries + 1):
             token_path.unlink(missing_ok=True)
-            logging.warning("dropping token after %d tries: %r", numtries - 1, token)
+            logging.warning("dropping token after %d tries: %r", numtries, token)
 
 
 def handle_dovecot_protocol(rfile, wfile, notifier):

--- a/chatmaild/src/chatmaild/metadata.py
+++ b/chatmaild/src/chatmaild/metadata.py
@@ -127,10 +127,10 @@ def main():
         logging.error("vmail dir does not exist: %r", vmail_dir)
         return 1
 
-    notification_dir = vmail_dir / "pending_notifications"
-    notification_dir.mkdir(exist_ok=True)
+    queue_dir = vmail_dir / "pending_notifications"
+    queue_dir.mkdir(exist_ok=True)
     metadata = Metadata(vmail_dir)
-    notifier = Notifier(notification_dir)
+    notifier = Notifier(queue_dir)
     notifier.start_notification_threads(metadata.remove_token_from_addr)
 
     class Handler(StreamRequestHandler):

--- a/chatmaild/src/chatmaild/notifier.py
+++ b/chatmaild/src/chatmaild/notifier.py
@@ -86,6 +86,10 @@ class Notifier:
 
     def requeue_persistent_queue_items(self):
         for queue_path in self.notification_dir.iterdir():
+            if queue_path.name.endswith(".tmp"):
+                logging.warning("removing spurious queue item: %r", queue_path)
+                queue_path.unlink()
+                continue
             queue_item = PersistentQueueItem.read_from_path(queue_path)
             self.queue_for_retry(queue_item)
 

--- a/chatmaild/src/chatmaild/notifier.py
+++ b/chatmaild/src/chatmaild/notifier.py
@@ -68,8 +68,8 @@ class Notifier:
     BASE_DELAY = 8.0  # base seconds for exponential back-off delay
     DROP_DEADLINE = 5 * 60 * 60  #  drop notifications after 5 hours
 
-    def __init__(self, notification_dir):
-        self.notification_dir = notification_dir
+    def __init__(self, queue_dir):
+        self.queue_dir = queue_dir
         max_tries = int(math.log(self.DROP_DEADLINE, self.BASE_DELAY)) + 1
         self.retry_queues = [PriorityQueue() for _ in range(max_tries)]
 
@@ -80,12 +80,12 @@ class Notifier:
         start_ts = int(time.time())
         for token in metadata.get_tokens_for_addr(addr):
             queue_item = PersistentQueueItem.create(
-                self.notification_dir, addr, start_ts, token
+                self.queue_dir, addr, start_ts, token
             )
             self.queue_for_retry(queue_item)
 
     def requeue_persistent_queue_items(self):
-        for queue_path in self.notification_dir.iterdir():
+        for queue_path in self.queue_dir.iterdir():
             if queue_path.name.endswith(".tmp"):
                 logging.warning("removing spurious queue item: %r", queue_path)
                 queue_path.unlink()

--- a/chatmaild/src/chatmaild/notifier.py
+++ b/chatmaild/src/chatmaild/notifier.py
@@ -1,0 +1,105 @@
+import time
+import logging
+from threading import Thread
+from queue import PriorityQueue
+import requests
+
+
+class Notifier:
+    URL = "https://notifications.delta.chat/notify"
+    CONNECTION_TIMEOUT = 60.0  # seconds until http-request is given up
+    NOTIFICATION_RETRY_DELAY = 8.0  # seconds with exponential backoff
+    MAX_NUMBER_OF_TRIES = 6
+    # exponential backoff means we try for 8^5 seconds, approximately 10 hours
+
+    def __init__(self, notification_dir):
+        self.notification_dir = notification_dir
+        self.retry_queues = [PriorityQueue() for _ in range(self.MAX_NUMBER_OF_TRIES)]
+
+    def new_message_for_addr(self, addr, metadata):
+        for token in metadata.get_tokens_for_addr(addr):
+            self.notification_dir.joinpath(token).write_text(addr)
+            self.add_token_for_retry(token)
+
+    def requeue_persistent_pending_tokens(self):
+        for token_path in self.notification_dir.iterdir():
+            self.add_token_for_retry(token_path.name)
+
+    def add_token_for_retry(self, token, retry_num=0):
+        if retry_num >= self.MAX_NUMBER_OF_TRIES:
+            return False
+
+        when = time.time()
+        if retry_num > 0:
+            # backup exponentially with number of retries
+            when += pow(self.NOTIFICATION_RETRY_DELAY, retry_num)
+        self.retry_queues[retry_num].put((when, token))
+        return True
+
+    def start_notification_threads(self, remove_token_from_addr):
+        self.requeue_persistent_pending_tokens()
+        threads = {}
+        for retry_num in range(len(self.retry_queues)):
+            num_threads = {0: 4}.get(retry_num, 2)
+            threads[retry_num] = []
+            for _ in range(num_threads):
+                thread = NotifyThread(self, retry_num, remove_token_from_addr)
+                threads[retry_num].append(thread)
+                thread.start()
+        return threads
+
+
+class NotifyThread(Thread):
+    def __init__(self, notifier, retry_num, remove_token_from_addr):
+        super().__init__(daemon=True)
+        self.notifier = notifier
+        self.retry_num = retry_num
+        self.remove_token_from_addr = remove_token_from_addr
+
+    def stop(self):
+        self.notifier.retry_queues[self.retry_num].put((None, None))
+
+    def run(self):
+        requests_session = requests.Session()
+        while self.retry_one(requests_session):
+            pass
+
+    def retry_one(self, requests_session, sleep=time.sleep):
+        # takes the next token from the per-retry-number PriorityQueue
+        # which is ordered by "when" (as set by add_token_for_retry()).
+        # If the request to notification server fails the token is
+        # queued to the next retry-number's PriorityQueue
+        # until it finally is dropped if MAX_NUMBER_OF_TRIES is exceeded
+        when, token = self.notifier.retry_queues[self.retry_num].get()
+        if when is None:
+            return False
+        wait_time = when - time.time()
+        if wait_time > 0:
+            sleep(wait_time)
+        self.perform_request_to_notification_server(requests_session, token)
+        return True
+
+    def perform_request_to_notification_server(self, requests_session, token):
+        token_path = self.notifier.notification_dir.joinpath(token)
+        try:
+            timeout = self.notifier.CONNECTION_TIMEOUT
+            res = requests_session.post(self.notifier.URL, data=token, timeout=timeout)
+        except requests.exceptions.RequestException as e:
+            res = e
+        else:
+            if res.status_code in (200, 410):
+                if res.status_code == 410:
+                    # 410 Gone: means the token is no longer valid.
+                    try:
+                        addr = token_path.read_text()
+                    except FileNotFoundError:
+                        logging.warning("no address for token %r:", token)
+                        return
+                    self.remove_token_from_addr(addr, token)
+                token_path.unlink(missing_ok=True)
+                return
+
+        logging.warning("Notification request failed: %r", res)
+        if not self.notifier.add_token_for_retry(token, retry_num=self.retry_num + 1):
+            token_path.unlink(missing_ok=True)
+            logging.warning("dropping token after %d tries: %r", self.retry_num, token)

--- a/chatmaild/src/chatmaild/tests/test_metadata.py
+++ b/chatmaild/src/chatmaild/tests/test_metadata.py
@@ -17,9 +17,9 @@ from chatmaild.notifier import (
 
 @pytest.fixture
 def notifier(metadata):
-    notification_dir = metadata.vmail_dir.joinpath("pending_notifications")
-    notification_dir.mkdir()
-    return Notifier(notification_dir)
+    queue_dir = metadata.vmail_dir.joinpath("pending_notifications")
+    queue_dir.mkdir()
+    return Notifier(queue_dir)
 
 
 @pytest.fixture
@@ -230,9 +230,9 @@ def test_notifier_thread_connection_failures(
 def test_requeue_removes_tmp_files(notifier, metadata, testaddr, caplog):
     metadata.add_token_to_addr(testaddr, "01234")
     notifier.new_message_for_addr(testaddr, metadata)
-    p = notifier.notification_dir.joinpath("1203981203.tmp")
+    p = notifier.queue_dir.joinpath("1203981203.tmp")
     p.touch()
-    notifier2 = notifier.__class__(notifier.notification_dir)
+    notifier2 = notifier.__class__(notifier.queue_dir)
     notifier2.requeue_persistent_queue_items()
     assert "spurious" in caplog.records[0].msg
     assert not p.exists()

--- a/chatmaild/src/chatmaild/tests/test_metadata.py
+++ b/chatmaild/src/chatmaild/tests/test_metadata.py
@@ -238,7 +238,7 @@ def test_requeue_removes_tmp_files(notifier, metadata, testaddr, caplog):
     assert not p.exists()
     assert notifier2.retry_queues[0].qsize() == 1
     when, queue_item = notifier2.retry_queues[0].get()
-    assert when >= int(time.time())
+    assert when <= int(time.time())
     assert queue_item.addr == testaddr
 
 
@@ -295,3 +295,4 @@ def test_persistent_queue_items(tmp_path, testaddr, token):
     assert item2 == queue_item
     item2.delete()
     assert not item2.path.exists()
+    assert not queue_item < item2 and not item2 < queue_item

--- a/chatmaild/src/chatmaild/tests/test_metadata.py
+++ b/chatmaild/src/chatmaild/tests/test_metadata.py
@@ -84,7 +84,7 @@ def test_handle_dovecot_request_happy_path(notifier, testaddr):
     assert handle_dovecot_request(f"B{tx2}\t{testaddr}", transactions, notifier) is None
     msg = f"S{tx2}\tpriv/guid00/messagenew"
     assert handle_dovecot_request(msg, transactions, notifier) is None
-    assert notifier.message_arrived_event.is_set()
+    assert notifier.notification_queue.get() == testaddr
     assert handle_dovecot_request(f"C{tx2}", transactions, notifier) == "O\n"
     assert not transactions
     assert notifier.notification_dir.joinpath(testaddr).exists()
@@ -159,8 +159,8 @@ def test_handle_dovecot_protocol_messagenew(notifier):
     wfile = io.BytesIO()
     handle_dovecot_protocol(rfile, wfile, notifier)
     assert wfile.getvalue() == b"O\n"
-    assert notifier.message_arrived_event.is_set()
-    assert notifier.notification_dir.joinpath("user@example.org").exists()
+    addr = notifier.notification_queue.get()
+    assert notifier.notification_dir.joinpath(addr).exists()
 
 
 def test_notifier_thread_run(notifier, testaddr):

--- a/chatmaild/src/chatmaild/tests/test_metadata.py
+++ b/chatmaild/src/chatmaild/tests/test_metadata.py
@@ -177,6 +177,8 @@ def test_notifier_thread_firstrun(notifier, testaddr):
     url, data, timeout = reqmock.requests[0]
     assert data == "01234"
     assert notifier.get_tokens(testaddr) == ["01234"]
+    notifier.requeue_persistent_pending_tokens()
+    assert notifier.retry_queues[0].qsize() == 0
 
 
 def test_notifier_thread_run(notifier, testaddr):
@@ -187,6 +189,8 @@ def test_notifier_thread_run(notifier, testaddr):
     url, data, timeout = reqmock.requests[0]
     assert data == "01234"
     assert notifier.get_tokens(testaddr) == ["01234"]
+    notifier.requeue_persistent_pending_tokens()
+    assert notifier.retry_queues[0].qsize() == 0
 
 
 @pytest.mark.parametrize("status", [requests.exceptions.RequestException(), 404, 500])
@@ -210,6 +214,8 @@ def test_notifier_thread_connection_failures(notifier, testaddr, status, caplog)
         else:
             assert len(caplog.records) == 2
             assert "giving up" in caplog.records[1].msg
+    notifier.requeue_persistent_pending_tokens()
+    assert notifier.retry_queues[0].qsize() == 0
 
 
 def test_multi_device_notifier(notifier, testaddr):


### PR DESCRIPTION
supersedes #263 

- uses a queue to keep notification ordering
- starts a couple of threads to handle "retry-buckets": a token with a failed notification requests goes into the next retry-bucket until it exceeds max number of buckets and it is dropped
- extensive tests also for the (rare) error cases 
- split "metadata" and "notification" logic into separate files
