### PR TITLE
DNS: ensure dig is installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## untagged 
 
+- Install dig on the server to resolve DNS records
+  ([#267](https://github.com/deltachat/chatmail/pull/267))
+
 - Run chatmail-metadata and doveauth as vmail
   ([#261](https://github.com/deltachat/chatmail/pull/261))
 

--- a/cmdeploy/src/cmdeploy/dns.py
+++ b/cmdeploy/src/cmdeploy/dns.py
@@ -11,7 +11,11 @@ class DNS:
         self.session = requests.Session()
         self.out = out
         self.ssh = f"ssh root@{mail_domain} -- "
-        self.out.shell_output(f"{ self.ssh }'apt-get update && apt-get install -y dnsutils'", timeout=60, no_print=True)
+        self.out.shell_output(
+            f"{ self.ssh }'apt-get update && apt-get install -y dnsutils'",
+            timeout=60,
+            no_print=True,
+        )
         try:
             self.shell(f"unbound-control flush_zone {mail_domain}")
         except subprocess.CalledProcessError:

--- a/cmdeploy/src/cmdeploy/dns.py
+++ b/cmdeploy/src/cmdeploy/dns.py
@@ -12,6 +12,11 @@ class DNS:
         self.out = out
         self.ssh = f"ssh root@{mail_domain} -- "
         try:
+            self.shell(f"apt update")
+            self.shell(f"apt install -y dnsutils")
+        except subprocess.CalledProcessError:
+            pass
+        try:
             self.shell(f"unbound-control flush_zone {mail_domain}")
         except subprocess.CalledProcessError:
             pass

--- a/cmdeploy/src/cmdeploy/dns.py
+++ b/cmdeploy/src/cmdeploy/dns.py
@@ -11,11 +11,7 @@ class DNS:
         self.session = requests.Session()
         self.out = out
         self.ssh = f"ssh root@{mail_domain} -- "
-        try:
-            self.shell(f"apt update")
-            self.shell(f"apt install -y dnsutils")
-        except subprocess.CalledProcessError:
-            pass
+        self.out.shell_output(f"{ self.ssh }'apt-get update && apt-get install -y dnsutils'", timeout=60, no_print=True)
         try:
             self.shell(f"unbound-control flush_zone {mail_domain}")
         except subprocess.CalledProcessError:


### PR DESCRIPTION
fix #219 

I ran `apt remove dnsutils && apt autoremove` on staging.testrun.org to test it.