### PR TITLE
WIP: added privacy_intro config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## untagged
 
+- Added a config option for an intro to the privacy policy
+  ([#285](https://github.com/deltachat/chatmail/pull/285))
+
 - Move echobot `into /var/lib/echobot`
   ([#281](https://github.com/deltachat/chatmail/pull/281))
 

--- a/chatmaild/src/chatmaild/config.py
+++ b/chatmaild/src/chatmaild/config.py
@@ -24,6 +24,7 @@ class Config:
         self.privacy_mail = params.get("privacy_mail")
         self.privacy_pdo = params.get("privacy_pdo")
         self.privacy_supervisor = params.get("privacy_supervisor")
+        self.privacy_intro = params.get("privacy_intro")
 
     def _getbytefile(self):
         return open(self._inipath, "rb")

--- a/chatmaild/src/chatmaild/ini/chatmail.ini.f
+++ b/chatmaild/src/chatmaild/ini/chatmail.ini.f
@@ -61,3 +61,4 @@ privacy_pdo =
 # postal address of the privacy supervisor
 privacy_supervisor =
 
+privacy_intro =

--- a/chatmaild/src/chatmaild/ini/override-testrun.ini
+++ b/chatmaild/src/chatmaild/ini/override-testrun.ini
@@ -14,3 +14,7 @@ privacy_pdo =
 privacy_supervisor =
     State Commissioner for Data Protection and Freedom of Information of
     Baden-Württemberg in 70173 Stuttgart, Germany.
+privacy_intro =
+    This is the default onboarding server for Delta Chat.
+    If you don't choose to login to an existing email account,
+    you can get one on this server.

--- a/www/src/privacy.md
+++ b/www/src/privacy.md
@@ -2,6 +2,8 @@
 
 # Privacy Policy for {{ config.mail_domain }} 
 
+{{ config.privacy_intro }}
+
 We want to show you in a fair and transparent way
 what personal data is processed by us.
 We follow a strict privacy-by-design approach


### PR DESCRIPTION
fixes #280 

https://staging.testrun.org/privacy.html already shows the new default wording for nine.testrun.org.