### PR TITLE
add doveauth basic iteration support

### DIFF
--- a/chatmaild/src/chatmaild/doveauth.py
+++ b/chatmaild/src/chatmaild/doveauth.py
@@ -129,6 +129,15 @@ def lookup_passdb(db, config: Config, user, cleartext_password):
         )
 
 
+def iter_userdb(db, config: Config) -> []:
+    """Get a list of all user addresses."""
+    with db.read_connection() as conn:
+        rows = conn.execute(
+            "SELECT addr from users",
+        ).fetchall()
+    return [x[0] for x in rows]
+
+
 def split_and_unescape(s):
     """Split strings using double quote as a separator and backslash as escape character
     into parts."""
@@ -192,6 +201,15 @@ def handle_dovecot_request(msg, db, config: Config):
                     reply_command = "N"
         json_res = json.dumps(res) if res else ""
         return f"{reply_command}{json_res}\n"
+    elif short_command == "I":  # LOOKUP
+        # example: I0\t0\tshared/userdb/
+        parts = msg[1:].split("\t")
+        if parts[2] == "shared/userdb/":
+            result = "".join(
+                f"Oshared/userdb/{user}\t\n" for user in iter_userdb(db, config)
+            )
+            return f"{result}\n"
+
     raise UnknownCommand(msg)
 
 

--- a/cmdeploy/src/cmdeploy/dovecot/auth.conf
+++ b/cmdeploy/src/cmdeploy/dovecot/auth.conf
@@ -1,5 +1,7 @@
 uri = proxy:/run/doveauth/doveauth.socket:auth
-iterate_disable = yes
+iterate_disable = no
+iterate_prefix = userdb/
+
 default_pass_scheme = plain
 # %E escapes characters " (double quote), ' (single quote) and \ (backslash) with \ (backslash).
 # See <https://doc.dovecot.org/configuration_manual/config_file/config_variables/#modifiers>


### PR DESCRIPTION
this is deployed to c2 and allows to list all users like this: 

```
doveadm user '*@c2.testrun.org'
```

or remove all seen messages on all mailboxes: 

```
doveadm expunge -A mailbox INBOX \( SEEN \)
```

or list all quotas in machine-readable format: 
```
doveadm  -f flow quota get -A
```
