### PR TITLE
remove fix-file-owner step 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## untagged
 
+- Don't fix file owner ship of /home/vmail 
+  ([#345](https://github.com/deltachat/chatmail/pull/345))
+
 - Support iterating over all users with doveadm commands 
   ([#344](https://github.com/deltachat/chatmail/pull/344))
 

--- a/cmdeploy/src/cmdeploy/__init__.py
+++ b/cmdeploy/src/cmdeploy/__init__.py
@@ -465,11 +465,6 @@ def deploy_chatmail(config_path: Path) -> None:
     )
     server.user(name="Create echobot user", user="echobot", system=True)
 
-    server.shell(
-        name="Fix file owner in /home/vmail",
-        commands=["test -d /home/vmail && chown -R vmail:vmail /home/vmail"],
-    )
-
     # Add our OBS repository for dovecot_no_delay
     files.put(
         name="Add Deltachat OBS GPG key to apt keyring",


### PR DESCRIPTION
which takes forever on servers with many mail directories

it's unclear why this is still needed and should be fixed differently in there is an actual problem. 
