### PR TITLE
feat: faster and simpler DNS checks, better ip-address determination

### DIFF
--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -72,12 +72,12 @@ jobs:
 
       - run: cmdeploy init staging2.testrun.org
 
-      - run: cmdeploy run
+      - run: cmdeploy run --verbose
 
       - name: set DNS entries
         run: |
           ssh -o StrictHostKeyChecking=accept-new -v root@staging2.testrun.org chown opendkim:opendkim -R /etc/dkimkeys
-          cmdeploy dns --zonefile staging-generated.zone
+          cmdeploy dns --zonefile staging-generated.zone --verbose
           cat staging-generated.zone >> .github/workflows/staging.testrun.org-default.zone
           cat .github/workflows/staging.testrun.org-default.zone
           scp .github/workflows/staging.testrun.org-default.zone root@ns.testrun.org:/etc/nsd/staging2.testrun.org.zone
@@ -88,5 +88,5 @@ jobs:
         run: CHATMAIL_DOMAIN2=nine.testrun.org cmdeploy test --slow
 
       - name: cmdeploy dns (try 3 times)
-        run: cmdeploy dns || cmdeploy dns || cmdeploy dns
+        run: cmdeploy dns -v || cmdeploy dns -v || cmdeploy dns -v
 

--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -76,7 +76,7 @@ jobs:
 
       - name: set DNS entries
         run: |
-          ssh -o StrictHostKeyChecking=accept-new -v root@staging2.testrun.org chown opendkim:opendkim -R /etc/dkimkeys
+          ssh -o StrictHostKeyChecking=accept-new root@staging2.testrun.org chown opendkim:opendkim -R /etc/dkimkeys
           cmdeploy dns --zonefile staging-generated.zone --verbose
           cat staging-generated.zone >> .github/workflows/staging.testrun.org-default.zone
           cat .github/workflows/staging.testrun.org-default.zone

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## untagged
 
-- Make DNS-checking faster and run it fully during "cmdeploy run",
-  introducing a generic mechanism for remote ssh-based python function execution. 
+- Make DNS-checking faster and more interactive, run it fully during "cmdeploy run",
+  also introducing a generic mechanism for rapid remote ssh-based python function execution. 
   ([#346](https://github.com/deltachat/chatmail/pull/346))
 
 - Don't fix file owner ship of /home/vmail 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## untagged
 
+- Make DNS-checking faster and run it fully during "cmdeploy run",
+  introducing a generic mechanism for remote ssh-based python function execution. 
+  ([#346](https://github.com/deltachat/chatmail/pull/346))
+
 - Don't fix file owner ship of /home/vmail 
   ([#345](https://github.com/deltachat/chatmail/pull/345))
 

--- a/cmdeploy/pyproject.toml
+++ b/cmdeploy/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
   "ruff",
   "pytest",
   "pytest-xdist", 
+  "execnet",
   "imap_tools",
 ]
 

--- a/cmdeploy/src/cmdeploy/__init__.py
+++ b/cmdeploy/src/cmdeploy/__init__.py
@@ -630,5 +630,3 @@ def deploy_chatmail(config_path: Path) -> None:
         name="Ensure cron is installed",
         packages=["cron"],
     )
-
-

--- a/cmdeploy/src/cmdeploy/cmdeploy.py
+++ b/cmdeploy/src/cmdeploy/cmdeploy.py
@@ -74,9 +74,8 @@ def dns_cmd_options(parser):
 
 
 def dns_cmd(args, out):
-    """Generate dns zone file."""
-    exit_code = show_dns(args, out)
-    exit(exit_code)
+    """Check DNS entries and optionally generate dns zone file."""
+    show_dns(args, out)
 
 
 def status_cmd(args, out):

--- a/cmdeploy/src/cmdeploy/cmdeploy.py
+++ b/cmdeploy/src/cmdeploy/cmdeploy.py
@@ -75,7 +75,7 @@ def dns_cmd_options(parser):
 
 def dns_cmd(args, out):
     """Check DNS entries and optionally generate dns zone file."""
-    show_dns(args, out)
+    return show_dns(args, out)
 
 
 def status_cmd(args, out):

--- a/cmdeploy/src/cmdeploy/cmdeploy.py
+++ b/cmdeploy/src/cmdeploy/cmdeploy.py
@@ -65,8 +65,9 @@ def run_cmd(args, out):
     if retcode == 0:
         out.green("Deploy completed, call `cmdeploy test` next.")
     elif not remote_data["acme_account_url"]:
-        out("Deploy completed but letsencrypt not configured, re-checking DNS")
-        return dns_cmd(args, out)
+        out.red("Deploy completed but letsencrypt not configured")
+        out.red("Run 'cmdeploy dns' or 'cmdeploy run' again")
+        retcode = 0
     else:
         out.red("Deploy failed")
     return retcode

--- a/cmdeploy/src/cmdeploy/cmdeploy.py
+++ b/cmdeploy/src/cmdeploy/cmdeploy.py
@@ -15,8 +15,9 @@ from pathlib import Path
 from chatmaild.config import read_config, write_initial_config
 from termcolor import colored
 
+from . import remote_funcs
 from .dns import show_dns
-from .sshexec import SSHExec, remote_funcs
+from .sshexec import SSHExec
 
 #
 # cmdeploy sub commands and options
@@ -81,7 +82,7 @@ def dns_cmd(args, out):
 def status_cmd(args, out):
     """Display status for online chatmail instance."""
 
-    sshexec = SSHExec(args.config.mail_domain)
+    sshexec = SSHExec(args.config.mail_domain, remote_funcs)
 
     out.green(f"chatmail domain: {args.config.mail_domain}")
     if args.config.privacy_mail:

--- a/cmdeploy/src/cmdeploy/cmdeploy.py
+++ b/cmdeploy/src/cmdeploy/cmdeploy.py
@@ -95,9 +95,7 @@ def status_cmd(args, out):
     else:
         out.red("no privacy settings")
 
-    s1 = "systemctl --type=service --state=running"
-
-    for line in ssh(s1).split("\n"):
+    for line in ssh("systemctl --type=service --state=running").split("\n"):
         if line.startswith("  "):
             print(line)
 

--- a/cmdeploy/src/cmdeploy/dns.py
+++ b/cmdeploy/src/cmdeploy/dns.py
@@ -15,26 +15,23 @@ class DNS:
             f"unbound-control flush_zone {mail_domain}"
         )
 
-    def shell(self, cmd):
-        return self.sshexec(cmd)
-
     def get_ipv4(self):
         cmd = "ip a | grep 'inet ' | grep 'scope global' | grep -oE '[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}' | head -1"
-        return self.shell(cmd).strip()
+        return self.sshexec(cmd).strip()
 
     def get_ipv6(self):
         cmd = "ip a | grep inet6 | grep 'scope global' | sed -e 's#/64 scope global##' | sed -e 's#inet6##'"
-        return self.shell(cmd).strip()
+        return self.sshexec(cmd).strip()
 
     def get(self, typ: str, domain: str) -> str:
         """Get a DNS entry or empty string if there is none."""
-        dig_result = self.shell(f"dig -r -q {domain} -t {typ} +short")
+        dig_result = self.sshexec(f"dig -r -q {domain} -t {typ} +short")
         line = dig_result.partition("\n")[0]
         return line
 
     def check_ptr_record(self, ip: str, mail_domain) -> bool:
         """Check the PTR record for an IPv4 or IPv6 address."""
-        result = self.shell(f"dig -r -x {ip} +short").rstrip()
+        result = self.sshexec(f"dig -r -x {ip} +short").rstrip()
         return result == f"{mail_domain}."
 
 

--- a/cmdeploy/src/cmdeploy/dns.py
+++ b/cmdeploy/src/cmdeploy/dns.py
@@ -18,17 +18,13 @@ def show_dns(args, out) -> int:
     assert remote_data["ipv4"] or remote_data["ipv6"]
 
     with open(template, "r") as f:
-        zonefile = (
-            f.read()
-            .format(
-                acme_account_url=remote_data["acme_account_url"],
-                dkim_entry=remote_data["dkim_entry"],
-                ipv6=remote_data["ipv6"],
-                ipv4=remote_data["ipv4"],
-                sts_id=datetime.datetime.now().strftime("%Y%m%d%H%M"),
-                chatmail_domain=args.config.mail_domain,
-            )
-            .strip()
+        zonefile = f.read().format(
+            acme_account_url=remote_data["acme_account_url"],
+            dkim_entry=remote_data["dkim_entry"],
+            ipv6=remote_data["ipv6"],
+            ipv4=remote_data["ipv4"],
+            sts_id=datetime.datetime.now().strftime("%Y%m%d%H%M"),
+            chatmail_domain=args.config.mail_domain,
         )
     if getattr(args, "zonefile", None):
         with open(args.zonefile, "w+") as zf:

--- a/cmdeploy/src/cmdeploy/dns.py
+++ b/cmdeploy/src/cmdeploy/dns.py
@@ -7,8 +7,8 @@ from .sshexec import SSHExec
 
 def show_dns(args, out) -> int:
     """Check existing DNS records, optionally write them to zone file
-    and return exit code 0 for success, non-zero otherwise."""
-    print("Checking your DKIM keys and DNS entries...")
+    and return (exitcode, remote_data) tuple."""
+    print("Checking DNS entries ...")
     template = importlib.resources.files(__package__).joinpath("chatmail.zone.f")
     mail_domain = args.config.mail_domain
 
@@ -60,4 +60,4 @@ def show_dns(args, out) -> int:
             "You can do so at your hosting provider (maybe this isn't your DNS provider)."
         )
 
-    return exit_code
+    return exit_code, remote_data

--- a/cmdeploy/src/cmdeploy/dns.py
+++ b/cmdeploy/src/cmdeploy/dns.py
@@ -11,16 +11,11 @@ def show_dns(args, out) -> int:
     template = importlib.resources.files(__package__).joinpath("chatmail.zone.f")
     mail_domain = args.config.mail_domain
 
-    if not args.verbose:
+    def log_progress(data):
+        sys.stdout.write(".")
+        sys.stdout.flush()
 
-        def log(data):
-            sys.stdout.write(".")
-            sys.stdout.flush()
-
-    else:
-        log = print
-
-    sshexec = args.get_sshexec(log=log)
+    sshexec = args.get_sshexec(log=print if args.verbose else log_progress)
     print("Checking DNS entries ", end="\n" if args.verbose else "")
 
     remote_data = sshexec(remote_funcs.perform_initial_checks, mail_domain=mail_domain)
@@ -45,6 +40,7 @@ def show_dns(args, out) -> int:
         with open(args.zonefile, "w+") as zf:
             zf.write(zonefile)
         out.green(f"DNS records successfully written to: {args.zonefile}")
+        return 0, remote_data
 
     if to_print:
         to_print.insert(

--- a/cmdeploy/src/cmdeploy/dns.py
+++ b/cmdeploy/src/cmdeploy/dns.py
@@ -6,7 +6,8 @@ from .sshexec import SSHExec
 
 
 def show_dns(args, out) -> int:
-    """Check existing DNS records, optionally write them to zone file, return exit code 0 or 1."""
+    """Check existing DNS records, optionally write them to zone file
+    and return exit code 0 for success, non-zero otherwise."""
     print("Checking your DKIM keys and DNS entries...")
     template = importlib.resources.files(__package__).joinpath("chatmail.zone.f")
     mail_domain = args.config.mail_domain
@@ -41,8 +42,10 @@ def show_dns(args, out) -> int:
             "\nIf you already configured the DNS entries, wait a bit until the DNS entries propagate to the Internet."
         )
         out.red("\n".join(to_print))
+        exit_code = 1
     else:
         out.green("Great! All your DNS entries are verified and correct.")
+        exit_code = 0
 
     to_print = []
     if not remote_data["reverse_ipv4"]:
@@ -56,3 +59,5 @@ def show_dns(args, out) -> int:
         out.red(
             "You can do so at your hosting provider (maybe this isn't your DNS provider)."
         )
+
+    return exit_code

--- a/cmdeploy/src/cmdeploy/dns.py
+++ b/cmdeploy/src/cmdeploy/dns.py
@@ -1,30 +1,8 @@
 import datetime
 import importlib
 
-import requests
-
+from . import remote_funcs
 from .sshexec import SSHExec
-
-
-class DNS:
-    def __init__(self, sshexec, mail_domain):
-        self.session = requests.Session()
-        self.sshexec = sshexec
-        self.sshexec(
-            "apt-get install -y dnsutils && "
-            f"unbound-control flush_zone {mail_domain}"
-        )
-
-    def get(self, typ: str, domain: str) -> str:
-        """Get a DNS entry or empty string if there is none."""
-        dig_result = self.sshexec(f"dig -r -q {domain} -t {typ} +short")
-        line = dig_result.partition("\n")[0]
-        return line
-
-    def check_ptr_record(self, ip: str, mail_domain) -> bool:
-        """Check the PTR record for an IPv4 or IPv6 address."""
-        result = self.sshexec(f"dig -r -x {ip} +short").rstrip()
-        return result == f"{mail_domain}."
 
 
 def show_dns(args, out) -> int:
@@ -35,147 +13,50 @@ def show_dns(args, out) -> int:
 
     sshexec = SSHExec(mail_domain)
 
-    try:
-        acme_account_url = sshexec("acmetool account-url")
-    except sshexec.RemoteError:
-        print("Please run `cmdeploy run` first.")
-        return 1
+    remote_data = sshexec(remote_funcs.perform_initial_checks, mail_domain=mail_domain)
 
-    dns = DNS(sshexec, mail_domain)
-
-    dkim_selector = "opendkim"
-    dkim_pubkey = sshexec(
-        f"openssl rsa -in /etc/dkimkeys/{dkim_selector}.private"
-        "-pubout 2>/dev/null | awk '/-/{next}{printf(\"%s\",$0)}'"
-    )
-    dkim_entry_value = f"v=DKIM1;k=rsa;p={dkim_pubkey};s=email;t=s"
-    dkim_entry_str = ""
-    while len(dkim_entry_value) >= 255:
-        dkim_entry_str += '"' + dkim_entry_value[:255] + '" '
-        dkim_entry_value = dkim_entry_value[255:]
-    dkim_entry_str += '"' + dkim_entry_value + '"'
-    dkim_entry = f"{dkim_selector}._domainkey.{mail_domain}. TXT {dkim_entry_str}"
-
-    ipv4, ipv6 = sshexec.get_ip_addresses()
-    assert ipv4 or ipv6
-
-    reverse_ipv4 = dns.check_ptr_record(ipv4, mail_domain) if ipv4 else None
-    reverse_ipv6 = dns.check_ptr_record(ipv6, mail_domain) if ipv6 else None
-
-    to_print = []
+    assert remote_data["ipv4"] or remote_data["ipv6"]
 
     with open(template, "r") as f:
         zonefile = (
             f.read()
             .format(
-                acme_account_url=acme_account_url,
+                acme_account_url=remote_data["acme_account_url"],
+                dkim_entry=remote_data["dkim_entry"],
+                ipv6=remote_data["ipv6"],
+                ipv4=remote_data["ipv4"],
                 sts_id=datetime.datetime.now().strftime("%Y%m%d%H%M"),
                 chatmail_domain=args.config.mail_domain,
-                dkim_entry=dkim_entry,
-                ipv6=ipv6,
-                ipv4=ipv4,
             )
             .strip()
         )
-    if args.zonefile:
+    if getattr(args, "zonefile", None):
         with open(args.zonefile, "w+") as zf:
             zf.write(zonefile)
         print(f"DNS records successfully written to: {args.zonefile}")
 
-    for line in zonefile.splitlines():
-        for typ in ["A", "AAAA", "CNAME", "CAA"]:
-            if f" {typ} " in line:
-                domain, value = line.split(f" {typ} ")
-                current = dns.get(typ, domain.strip()[:-1])
-                if current != value.strip():
-                    to_print.append(line)
-        if " MX " in line:
-            domain, typ, prio, value = line.split()
-            current = dns.get(typ, domain[:-1])
-            if not current:
-                to_print.append(line)
-            elif current.split()[1] != value:
-                print(line.replace(prio, str(int(current[0]) + 1)))
-        if " SRV " in line:
-            domain, typ, prio, weight, port, value = line.split()
-            current = dns.get("SRV", domain[:-1])
-            if current != f"{prio} {weight} {port} {value}":
-                to_print.append(line)
-        if " TXT " in line:
-            domain, value = line.split(" TXT ")
-            current = dns.get("TXT", domain.strip()[:-1])
-            if domain.startswith("_mta-sts."):
-                if current:
-                    if current.split("id=")[0] == value.split("id=")[0]:
-                        continue
+    to_print = sshexec(remote_funcs.check_zonefile, zonefile=zonefile)
 
-            # TXT records longer than 255 bytes
-            # are split into multiple <character-string>s.
-            # This typically happens with DKIM record
-            # which contains long RSA key.
-            #
-            # Removing `" "` before comparison
-            # to get back a single string.
-            if current.replace('" "', "") != value.replace('" "', ""):
-                to_print.append(line)
-
-    exit_code = 0
     if to_print:
         to_print.insert(
-            0, "You should configure the following DNS entries at your provider:\n"
+            0, "You should configure the following entries at your DNS provider:\n"
         )
         to_print.append(
             "\nIf you already configured the DNS entries, wait a bit until the DNS entries propagate to the Internet."
         )
-        print("\n".join(to_print))
-        exit_code = 1
+        out.red("\n".join(to_print))
     else:
-        out.green("Great! All your DNS entries are correct.")
+        out.green("Great! All your DNS entries are verified and correct.")
 
     to_print = []
-    if not reverse_ipv4:
-        to_print.append(f"\tIPv4:\t{ipv4}\t{args.config.mail_domain}")
-    if not reverse_ipv6:
-        to_print.append(f"\tIPv6:\t{ipv6}\t{args.config.mail_domain}")
+    if not remote_data["reverse_ipv4"]:
+        to_print.append(f"\tIPv4:\t{remote_data['ipv4']}\t{args.config.mail_domain}")
+    if not remote_data["reverse_ipv6"]:
+        to_print.append(f"\tIPv6:\t{remote_data['ipv6']}\t{args.config.mail_domain}")
     if len(to_print) > 0:
-        if len(to_print) == 1:
-            warning = "You should add the following PTR/reverse DNS entry:"
-        else:
-            warning = "You should add the following PTR/reverse DNS entries:"
-        out.red(warning)
+        out.red("You need to set the following PTR/reverse DNS data:")
         for entry in to_print:
             print(entry)
-        print(
+        out.red(
             "You can do so at your hosting provider (maybe this isn't your DNS provider)."
         )
-        exit_code = 1
-    return exit_code
-
-
-def check_necessary_dns(out, mail_domain):
-    """Check whether $mail_domain and mta-sts.$mail_domain resolve."""
-    print("Checking necessary DNS records... ")
-    sshexec = SSHExec(mail_domain)
-    dns = DNS(sshexec, mail_domain)
-    ipv4 = dns.get("A", mail_domain)
-    ipv6 = dns.get("AAAA", mail_domain)
-    mta_entry = dns.get("CNAME", "mta-sts." + mail_domain)
-    www_entry = dns.get("CNAME", "www." + mail_domain)
-    to_print = []
-    if not (ipv4 or ipv6):
-        to_print.append(f"\t{mail_domain}.\t\t\tA<your server's IPv4 address>")
-    if mta_entry != mail_domain + ".":
-        to_print.append(f"\tmta-sts.{mail_domain}.\tCNAME\t{mail_domain}.")
-    if www_entry != mail_domain + ".":
-        to_print.append(f"\twww.{mail_domain}.\tCNAME\t{mail_domain}.")
-    if to_print:
-        to_print.insert(
-            0,
-            "\nFor chatmail to work, you need to configure this at your DNS provider:\n",
-        )
-        for line in to_print:
-            print(line)
-        print()
-    else:
-        out.green("All necessary DNS records seem to be set.")
-        return True

--- a/cmdeploy/src/cmdeploy/dns.py
+++ b/cmdeploy/src/cmdeploy/dns.py
@@ -11,7 +11,7 @@ def show_dns(args, out) -> int:
     template = importlib.resources.files(__package__).joinpath("chatmail.zone.f")
     mail_domain = args.config.mail_domain
 
-    sshexec = SSHExec(mail_domain)
+    sshexec = SSHExec(mail_domain, remote_funcs)
 
     remote_data = sshexec(remote_funcs.perform_initial_checks, mail_domain=mail_domain)
 

--- a/cmdeploy/src/cmdeploy/remote_funcs.py
+++ b/cmdeploy/src/cmdeploy/remote_funcs.py
@@ -34,7 +34,7 @@ def perform_initial_checks(mail_domain):
 
     res["acme_account_url"] = shell("acmetool account-url", fail_ok=True)
     shell("apt-get install -y dnsutils")
-    shell("unbound-control flush_zone {mail_domain}", fail_ok=True)
+    shell(f"unbound-control flush_zone {mail_domain}", fail_ok=True)
 
     res["dkim_entry"] = get_dkim_entry(mail_domain, dkim_selector="opendkim")
 

--- a/cmdeploy/src/cmdeploy/remote_funcs.py
+++ b/cmdeploy/src/cmdeploy/remote_funcs.py
@@ -1,0 +1,117 @@
+"""
+Functions to be executed on an ssh-connected host.
+
+All functions of this module need to work with Python builtin types
+and standard library dependencies only.
+
+When a remote function executes remotely, it runs in a system python interpreter
+without any installed dependencies.
+
+"""
+
+import socket
+from subprocess import check_output
+
+
+def shell(command):
+    return check_output(command, shell=True).decode().rstrip()
+
+
+def get_systemd_running():
+    lines = shell("systemctl --type=service --state=running").split("\n")
+    return [line for line in lines if line.startswith("  ")]
+
+
+def perform_initial_checks(mail_domain):
+    res = {}
+
+    res["acme_account_url"] = shell("acmetool account-url")
+    shell("apt-get install -y dnsutils")
+    shell("unbound-control flush_zone {mail_domain}")
+
+    res["dkim_entry"] = get_dkim_entry(mail_domain, dkim_selector="opendkim")
+
+    ipv4, reverse_ipv4 = get_ip_address_and_reverse(socket.AF_INET)
+    ipv6, reverse_ipv6 = get_ip_address_and_reverse(socket.AF_INET6)
+    res.update(dict(ipv4=ipv4, reverse_ipv4=reverse_ipv4))
+    res.update(dict(ipv6=ipv6, reverse_ipv6=reverse_ipv6))
+    return res
+
+
+def get_dkim_entry(mail_domain, dkim_selector):
+    dkim_pubkey = shell(
+        f"openssl rsa -in /etc/dkimkeys/{dkim_selector}.private"
+        "-pubout 2>/dev/null | awk '/-/{next}{printf(\"%s\",$0)}'"
+    )
+    dkim_entry_value = f"v=DKIM1;k=rsa;p={dkim_pubkey};s=email;t=s"
+    dkim_entry_str = ""
+    while len(dkim_entry_value) >= 255:
+        dkim_entry_str += '"' + dkim_entry_value[:255] + '" '
+        dkim_entry_value = dkim_entry_value[255:]
+    dkim_entry_str += '"' + dkim_entry_value + '"'
+    return f"{dkim_selector}._domainkey.{mail_domain}. TXT {dkim_entry_str}"
+
+
+def get_ip_address_and_reverse(typ):
+    sock = socket.socket(typ, socket.SOCK_DGRAM)
+    sock.settimeout(0)
+    sock.connect(("notifications.delta.chat", 1))
+    ip = sock.getsockname()[0]
+    return ip, shell(f"dig -r -x {ip} +short").rstrip(".")
+
+
+def query_dns(typ, domain):
+    res = shell(f"dig -r -q {domain} -t {typ} +short")
+    return res.partition("\n")[0]
+
+
+def check_zonefile(zonefile):
+    diff = []
+
+    for line in zonefile.splitlines():
+        for typ in ["A", "AAAA", "CNAME", "CAA"]:
+            if f" {typ} " in line:
+                domain, value = line.split(f" {typ} ")
+                current = query_dns(typ, domain.strip()[:-1])
+                if current != value.strip():
+                    diff.append(line)
+        if " MX " in line:
+            domain, typ, prio, value = line.split()
+            current = query_dns(typ, domain[:-1])
+            if not current:
+                diff.append(line)
+            elif current.split()[1] != value:
+                diff.append(line.replace(prio, str(int(current[0]) + 1)))
+        if " SRV " in line:
+            domain, typ, prio, weight, port, value = line.split()
+            current = query_dns("SRV", domain[:-1])
+            if current != f"{prio} {weight} {port} {value}":
+                diff.append(line)
+        if " TXT " in line:
+            domain, value = line.split(" TXT ")
+            current = query_dns("TXT", domain.strip()[:-1])
+            if domain.startswith("_mta-sts."):
+                if current:
+                    if current.split("id=")[0] == value.split("id=")[0]:
+                        continue
+
+            # TXT records longer than 255 bytes
+            # are split into multiple <character-string>s.
+            # This typically happens with DKIM record
+            # which contains long RSA key.
+            #
+            # Removing `" "` before comparison
+            # to get back a single string.
+            if current.replace('" "', "") != value.replace('" "', ""):
+                diff.append(line)
+
+    return diff
+
+
+# check if this module is executed remotely
+# and setup a simple serialized function-execution loop
+
+if __name__ == "__channelexec__":
+    while 1:
+        func_name, kwargs = channel.receive()  # noqa
+        channel.send(globals()[func_name](**kwargs))  # noqa

--- a/cmdeploy/src/cmdeploy/remote_funcs.py
+++ b/cmdeploy/src/cmdeploy/remote_funcs.py
@@ -78,6 +78,10 @@ def check_zonefile(zonefile):
         if zf_value in query_values:
             continue
 
+        if zf_typ == "CAA" and zf_value.endswith("accounturi="):
+            # this is an initial run where acmetool did not work yet
+            continue
+
         if query_values and zf_typ == "TXT" and zf_domain.startswith("_mta-sts."):
             (query_value,) = query_values
             if query_value.split("id=")[0] == zf_value.split("id=")[0]:

--- a/cmdeploy/src/cmdeploy/remote_funcs.py
+++ b/cmdeploy/src/cmdeploy/remote_funcs.py
@@ -15,6 +15,7 @@ from subprocess import CalledProcessError, check_output
 
 
 def shell(command, fail_ok=False):
+    log(f"$ {command}")
     try:
         return check_output(command, shell=True).decode().rstrip()
     except CalledProcessError:
@@ -97,6 +98,11 @@ def check_zonefile(zonefile):
 # and setup a simple serialized function-execution loop
 
 if __name__ == "__channelexec__":
+
+    def log(item):
+        channel.send(("log", item))  # noqa
+
     while 1:
         func_name, kwargs = channel.receive()  # noqa
-        channel.send(globals()[func_name](**kwargs))  # noqa
+        res = globals()[func_name](**kwargs)  # noqa
+        channel.send(("finish", res))  # noqa

--- a/cmdeploy/src/cmdeploy/remote_funcs.py
+++ b/cmdeploy/src/cmdeploy/remote_funcs.py
@@ -11,11 +11,16 @@ without any installed dependencies.
 
 import re
 import socket
-from subprocess import check_output
+from subprocess import CalledProcessError, check_output
 
 
-def shell(command):
-    return check_output(command, shell=True).decode().rstrip()
+def shell(command, fail_ok=False):
+    try:
+        return check_output(command, shell=True).decode().rstrip()
+    except CalledProcessError:
+        if not fail_ok:
+            raise
+        return ""
 
 
 def get_systemd_running():
@@ -26,9 +31,9 @@ def get_systemd_running():
 def perform_initial_checks(mail_domain):
     res = {}
 
-    res["acme_account_url"] = shell("acmetool account-url")
+    res["acme_account_url"] = shell("acmetool account-url", fail_ok=True)
     shell("apt-get install -y dnsutils")
-    shell("unbound-control flush_zone {mail_domain}")
+    shell("unbound-control flush_zone {mail_domain}", fail_ok=True)
 
     res["dkim_entry"] = get_dkim_entry(mail_domain, dkim_selector="opendkim")
 

--- a/cmdeploy/src/cmdeploy/remote_funcs.py
+++ b/cmdeploy/src/cmdeploy/remote_funcs.py
@@ -79,7 +79,7 @@ def check_zonefile(zonefile):
         if zf_value in query_values:
             continue
 
-        if zf_typ == "CAA" and zf_value.endswith("accounturi="):
+        if zf_typ == "CAA" and zf_value.endswith('accounturi="'):
             # this is an initial run where acmetool did not work yet
             continue
 

--- a/cmdeploy/src/cmdeploy/remote_funcs.py
+++ b/cmdeploy/src/cmdeploy/remote_funcs.py
@@ -33,7 +33,8 @@ def perform_initial_checks(mail_domain):
     res = {}
 
     res["acme_account_url"] = shell("acmetool account-url", fail_ok=True)
-    shell("apt-get install -y dnsutils")
+    if not shell("dig", fail_ok=True):
+        shell("apt-get install -y dnsutils")
     shell(f"unbound-control flush_zone {mail_domain}", fail_ok=True)
 
     res["dkim_entry"] = get_dkim_entry(mail_domain, dkim_selector="opendkim")

--- a/cmdeploy/src/cmdeploy/remote_funcs.py
+++ b/cmdeploy/src/cmdeploy/remote_funcs.py
@@ -40,7 +40,7 @@ def perform_initial_checks(mail_domain):
 
 def get_dkim_entry(mail_domain, dkim_selector):
     dkim_pubkey = shell(
-        f"openssl rsa -in /etc/dkimkeys/{dkim_selector}.private"
+        f"openssl rsa -in /etc/dkimkeys/{dkim_selector}.private "
         "-pubout 2>/dev/null | awk '/-/{next}{printf(\"%s\",$0)}'"
     )
     dkim_entry_value = f"v=DKIM1;k=rsa;p={dkim_pubkey};s=email;t=s"

--- a/cmdeploy/src/cmdeploy/sshexec.py
+++ b/cmdeploy/src/cmdeploy/sshexec.py
@@ -4,12 +4,18 @@ import execnet
 class SSHExec:
     RemoteError = execnet.RemoteError
 
-    def __init__(self, host, remote_funcs, python="python3", timeout=60):
-        target = host if "@" in host else f"root@{host}"
-        self.gateway = execnet.makegateway(f"ssh={target}//python={python}")
+    def __init__(self, host, remote_funcs, log=None, python="python3", timeout=60):
+        self.ssh_target = host if "@" in host else f"root@{host}"
+        self.gateway = execnet.makegateway(f"ssh={self.ssh_target}//python={python}")
         self._remote_cmdloop_channel = self.gateway.remote_exec(remote_funcs)
+        self.log = log
         self.timeout = timeout
 
     def __call__(self, func, **kwargs):
         self._remote_cmdloop_channel.send((func.__name__, kwargs))
-        return self._remote_cmdloop_channel.receive(timeout=self.timeout)
+        while 1:
+            code, data = self._remote_cmdloop_channel.receive(timeout=self.timeout)
+            if code == "log" and self.log:
+                self.log(data)
+            elif code == "finish":
+                return data

--- a/cmdeploy/src/cmdeploy/sshexec.py
+++ b/cmdeploy/src/cmdeploy/sshexec.py
@@ -10,15 +10,33 @@ def exec_one_command(channel, cmd):
     channel.send(output)
 
 
+def get_ip_addresses(channel):
+    import socket
+
+    res = []
+    for typ in (socket.AF_INET, socket.AF_INET6):
+        sock = socket.socket(typ, socket.SOCK_DGRAM)
+        sock.settimeout(0)
+        sock.connect(("notifications.delta.chat", 1))
+        res.append(sock.getsockname()[0])
+
+    channel.send(res)
+
+
 class SSHExec:
     RemoteError = execnet.RemoteError
 
-    def __init__(self, host, python="python3"):
+    def __init__(self, host, python="python3", timeout=60):
         target = host if "@" in host else f"root@{host}"
         self.gateway = execnet.makegateway(f"ssh={target}//python={python}")
+        self.timeout = timeout
 
-    def __call__(self, cmd, timeout=60, quiet=False):
+    def __call__(self, cmd, quiet=False):
         if not quiet:
             print(f"{self.gateway.spec.ssh} $ {cmd}")
         channel = self.gateway.remote_exec(exec_one_command, cmd=cmd)
-        return channel.receive(timeout=timeout)
+        return channel.receive(timeout=self.timeout)
+
+    def get_ip_addresses(self):
+        channel = self.gateway.remote_exec(get_ip_addresses)
+        return channel.receive(timeout=self.timeout)

--- a/cmdeploy/src/cmdeploy/sshexec.py
+++ b/cmdeploy/src/cmdeploy/sshexec.py
@@ -2,21 +2,23 @@ import execnet
 
 
 def exec_one_command(channel, cmd):
-    # this code executes on the remote ssh side
-    # the channel can be used to send back results
+    # a pure function which executes on the remote ssh side
+    # with the channel providing I/O
     import subprocess
 
     output = subprocess.check_output(cmd, shell=True).decode()
     channel.send(output)
 
 
-class SSHCommandExecutor:
+class SSHExec:
     RemoteError = execnet.RemoteError
 
     def __init__(self, host, python="python3"):
-        self.gateway = execnet.makegateway(f"ssh=root@{host}//python={python}")
+        target = host if "@" in host else f"root@{host}"
+        self.gateway = execnet.makegateway(f"ssh={target}//python={python}")
 
-    def shell_output(self, cmd, timeout=60):
-        print(f"{self.gateway.spec.ssh} $ {cmd}")
+    def __call__(self, cmd, timeout=60, quiet=False):
+        if not quiet:
+            print(f"{self.gateway.spec.ssh} $ {cmd}")
         channel = self.gateway.remote_exec(exec_one_command, cmd=cmd)
         return channel.receive(timeout=timeout)

--- a/cmdeploy/src/cmdeploy/sshexec.py
+++ b/cmdeploy/src/cmdeploy/sshexec.py
@@ -1,0 +1,22 @@
+import execnet
+
+
+def exec_one_command(channel, cmd):
+    # this code executes on the remote ssh side
+    # the channel can be used to send back results
+    import subprocess
+
+    output = subprocess.check_output(cmd, shell=True).decode()
+    channel.send(output)
+
+
+class SSHCommandExecutor:
+    RemoteError = execnet.RemoteError
+
+    def __init__(self, host, python="python3"):
+        self.gateway = execnet.makegateway(f"ssh=root@{host}//python={python}")
+
+    def shell_output(self, cmd, timeout=60):
+        print(f"{self.gateway.spec.ssh} $ {cmd}")
+        channel = self.gateway.remote_exec(exec_one_command, cmd=cmd)
+        return channel.receive(timeout=timeout)

--- a/cmdeploy/src/cmdeploy/sshexec.py
+++ b/cmdeploy/src/cmdeploy/sshexec.py
@@ -5,8 +5,7 @@ class SSHExec:
     RemoteError = execnet.RemoteError
 
     def __init__(self, host, remote_funcs, log=None, python="python3", timeout=60):
-        self.ssh_target = host if "@" in host else f"root@{host}"
-        self.gateway = execnet.makegateway(f"ssh={self.ssh_target}//python={python}")
+        self.gateway = execnet.makegateway(f"ssh=root@{host}//python={python}")
         self._remote_cmdloop_channel = self.gateway.remote_exec(remote_funcs)
         self.log = log
         self.timeout = timeout

--- a/cmdeploy/src/cmdeploy/sshexec.py
+++ b/cmdeploy/src/cmdeploy/sshexec.py
@@ -1,26 +1,6 @@
 import execnet
 
-
-def exec_one_command(channel, cmd):
-    # a pure function which executes on the remote ssh side
-    # with the channel providing I/O
-    import subprocess
-
-    output = subprocess.check_output(cmd, shell=True).decode()
-    channel.send(output)
-
-
-def get_ip_addresses(channel):
-    import socket
-
-    res = []
-    for typ in (socket.AF_INET, socket.AF_INET6):
-        sock = socket.socket(typ, socket.SOCK_DGRAM)
-        sock.settimeout(0)
-        sock.connect(("notifications.delta.chat", 1))
-        res.append(sock.getsockname()[0])
-
-    channel.send(res)
+from . import remote_funcs
 
 
 class SSHExec:
@@ -29,14 +9,9 @@ class SSHExec:
     def __init__(self, host, python="python3", timeout=60):
         target = host if "@" in host else f"root@{host}"
         self.gateway = execnet.makegateway(f"ssh={target}//python={python}")
+        self._remote_cmdloop_channel = self.gateway.remote_exec(remote_funcs)
         self.timeout = timeout
 
-    def __call__(self, cmd, quiet=False):
-        if not quiet:
-            print(f"{self.gateway.spec.ssh} $ {cmd}")
-        channel = self.gateway.remote_exec(exec_one_command, cmd=cmd)
-        return channel.receive(timeout=self.timeout)
-
-    def get_ip_addresses(self):
-        channel = self.gateway.remote_exec(get_ip_addresses)
-        return channel.receive(timeout=self.timeout)
+    def __call__(self, func, **kwargs):
+        self._remote_cmdloop_channel.send((func.__name__, kwargs))
+        return self._remote_cmdloop_channel.receive(timeout=self.timeout)

--- a/cmdeploy/src/cmdeploy/sshexec.py
+++ b/cmdeploy/src/cmdeploy/sshexec.py
@@ -1,12 +1,10 @@
 import execnet
 
-from . import remote_funcs
-
 
 class SSHExec:
     RemoteError = execnet.RemoteError
 
-    def __init__(self, host, python="python3", timeout=60):
+    def __init__(self, host, remote_funcs, python="python3", timeout=60):
         target = host if "@" in host else f"root@{host}"
         self.gateway = execnet.makegateway(f"ssh={target}//python={python}")
         self._remote_cmdloop_channel = self.gateway.remote_exec(remote_funcs)

--- a/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
@@ -2,6 +2,22 @@ import smtplib
 
 import pytest
 
+from cmdeploy.sshexec import SSHCommandExecutor
+
+
+class TestSSHExecutor:
+    def test_ls(self, sshdomain):
+        ssh = SSHCommandExecutor(sshdomain)
+        out = ssh.shell_output("ls")
+        out2 = ssh.shell_output("ls")
+        assert out == out2
+
+    def test_failed_command(self, sshdomain):
+        ssh = SSHCommandExecutor(sshdomain)
+        with pytest.raises(ssh.RemoteError) as s:
+            ssh.shell_output("qlwkejqlwkejqlwe")
+        assert "exit status 127" in str(s)
+
 
 def test_remote(remote, imap_or_smtp):
     lineproducer = remote.iter_output(imap_or_smtp.logcmd)

--- a/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
@@ -6,17 +6,23 @@ from cmdeploy.sshexec import SSHExec
 
 
 class TestSSHExecutor:
-    def test_ls(self, sshdomain):
-        ssh = SSHExec(sshdomain)
+    @pytest.fixture
+    def ssh(self, sshdomain):
+        return SSHExec(sshdomain)
+
+    def test_ls(self, ssh):
         out = ssh("ls")
         out2 = ssh("ls")
         assert out == out2
 
-    def test_failed_command(self, sshdomain):
-        ssh = SSHExec(sshdomain)
+    def test_failed_command(self, ssh):
         with pytest.raises(ssh.RemoteError) as s:
             ssh("qlwkejqlwkejqlwe")
         assert "exit status 127" in str(s)
+
+    def test_get_ip_addresses(self, ssh):
+        ipv4, ipv6 = ssh.get_ip_addresses()
+        assert ipv4 or ipv6
 
 
 def test_remote(remote, imap_or_smtp):

--- a/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
@@ -8,16 +8,16 @@ from cmdeploy.sshexec import SSHExec
 
 class TestSSHExecutor:
     @pytest.fixture
-    def ssh(self, sshdomain):
-        return SSHExec(sshdomain)
+    def sshexec(self, sshdomain):
+        return SSHExec(sshdomain, remote_funcs)
 
-    def test_ls(self, ssh):
-        out = ssh(remote_funcs.shell, command="ls")
-        out2 = ssh(remote_funcs.shell, command="ls")
+    def test_ls(self, sshexec):
+        out = sshexec(remote_funcs.shell, command="ls")
+        out2 = sshexec(remote_funcs.shell, command="ls")
         assert out == out2
 
-    def test_perform_initial(self, ssh, maildomain):
-        res = ssh(remote_funcs.perform_initial_checks, mail_domain=maildomain)
+    def test_perform_initial(self, sshexec, maildomain):
+        res = sshexec(remote_funcs.perform_initial_checks, mail_domain=maildomain)
         assert res["ipv4"] or res["ipv6"]
 
 

--- a/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
@@ -2,6 +2,7 @@ import smtplib
 
 import pytest
 
+from cmdeploy import remote_funcs
 from cmdeploy.sshexec import SSHExec
 
 
@@ -11,18 +12,13 @@ class TestSSHExecutor:
         return SSHExec(sshdomain)
 
     def test_ls(self, ssh):
-        out = ssh("ls")
-        out2 = ssh("ls")
+        out = ssh(remote_funcs.shell, command="ls")
+        out2 = ssh(remote_funcs.shell, command="ls")
         assert out == out2
 
-    def test_failed_command(self, ssh):
-        with pytest.raises(ssh.RemoteError) as s:
-            ssh("qlwkejqlwkejqlwe")
-        assert "exit status 127" in str(s)
-
-    def test_get_ip_addresses(self, ssh):
-        ipv4, ipv6 = ssh.get_ip_addresses()
-        assert ipv4 or ipv6
+    def test_perform_initial(self, ssh, maildomain):
+        res = ssh(remote_funcs.perform_initial_checks, mail_domain=maildomain)
+        assert res["ipv4"] or res["ipv6"]
 
 
 def test_remote(remote, imap_or_smtp):

--- a/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
+++ b/cmdeploy/src/cmdeploy/tests/online/test_1_basic.py
@@ -2,20 +2,20 @@ import smtplib
 
 import pytest
 
-from cmdeploy.sshexec import SSHCommandExecutor
+from cmdeploy.sshexec import SSHExec
 
 
 class TestSSHExecutor:
     def test_ls(self, sshdomain):
-        ssh = SSHCommandExecutor(sshdomain)
-        out = ssh.shell_output("ls")
-        out2 = ssh.shell_output("ls")
+        ssh = SSHExec(sshdomain)
+        out = ssh("ls")
+        out2 = ssh("ls")
         assert out == out2
 
     def test_failed_command(self, sshdomain):
-        ssh = SSHCommandExecutor(sshdomain)
+        ssh = SSHExec(sshdomain)
         with pytest.raises(ssh.RemoteError) as s:
-            ssh.shell_output("qlwkejqlwkejqlwe")
+            ssh("qlwkejqlwkejqlwe")
         assert "exit status 127" in str(s)
 
 


### PR DESCRIPTION
shrinks and streamlines the DNS-checking code to use 'execnet' which allows to execute python functions remotely. 

- DNS-checking is much faster as the ssh-connection is re-used, and there are much fewer roundtrips. 

- Instead of parsing the output of the "ip" command this PR uses a standard python "socket" pattern to determine IPV4 and IPV6 addresses.  This is likely less dependent on the target enviroment, so could also work better with non-debian systems.  

- DNS checking now gives progress indicators (use -v|--verbose to see commands executed remotely) 
