### PR TITLE
automatically delete inactive users from database and mail directories 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## untagged
 
+- BREAKING: new required chatmail.ini value 'delete_inactive_users_after = 25'
+  which removes users from database and mails after 25 days without any login. 
+
 - remove checking of reverse-DNS PTR records.  Chatmail-servers don't
   depend on it and even in the wider e-mail system it's not common anymore. 
   If it's an issue, a chatmail operator can still care to properly set reverse DNS. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - BREAKING: new required chatmail.ini value 'delete_inactive_users_after = 25'
   which removes users from database and mails after 25 days without any login. 
+  ([#350](https://github.com/deltachat/chatmail/pull/350))
 
 - remove checking of reverse-DNS PTR records.  Chatmail-servers don't
   depend on it and even in the wider e-mail system it's not common anymore. 

--- a/chatmaild/pyproject.toml
+++ b/chatmaild/pyproject.toml
@@ -26,6 +26,7 @@ chatmail-metadata = "chatmaild.metadata:main"
 filtermail = "chatmaild.filtermail:main"
 echobot = "chatmaild.echo:main"
 chatmail-metrics = "chatmaild.metrics:main"
+delete_inactive_users = "chatmaild.delete_inactive_users:main"
 
 [project.entry-points.pytest11]
 "chatmaild.testplugin" = "chatmaild.tests.plugin"

--- a/chatmaild/src/chatmaild/config.py
+++ b/chatmaild/src/chatmaild/config.py
@@ -38,9 +38,11 @@ class Config:
         return open(self._inipath, "rb")
 
     def get_user_maildir(self, addr):
-        if not addr or "/" in addr:
-            raise ValueError(addr)
-        return self.mail_basedir.joinpath(addr)
+        if addr and addr != "." and "/" not in addr:
+            res = self.mail_basedir.joinpath(addr).resolve()
+            if res.is_relative_to(self.mail_basedir):
+                return res
+        raise ValueError(f"invalid address {addr!r}")
 
 
 def write_initial_config(inipath, mail_domain):

--- a/chatmaild/src/chatmaild/config.py
+++ b/chatmaild/src/chatmaild/config.py
@@ -3,18 +3,22 @@ from pathlib import Path
 import iniconfig
 
 
-def read_config(inipath):
+def read_config(inipath, mail_basedir=None):
     cfg = iniconfig.IniConfig(inipath)
-    return Config(inipath, params=cfg.sections["params"])
+    params = cfg.sections["params"]
+    if mail_basedir is None:
+        mail_basedir = Path(f"/home/vmail/mail/{params['mail_domain']}")
+    return Config(inipath, params=params, mail_basedir=mail_basedir)
 
 
 class Config:
-    def __init__(self, inipath, params):
+    def __init__(self, inipath, params, mail_basedir):
         self._inipath = inipath
         self.mail_domain = params["mail_domain"]
         self.max_user_send_per_minute = int(params["max_user_send_per_minute"])
         self.max_mailbox_size = params["max_mailbox_size"]
         self.delete_mails_after = params["delete_mails_after"]
+        self.delete_inactive_users_after = int(params["delete_inactive_users_after"])
         self.username_min_length = int(params["username_min_length"])
         self.username_max_length = int(params["username_max_length"])
         self.password_min_length = int(params["password_min_length"])
@@ -27,7 +31,7 @@ class Config:
         self.privacy_mail = params.get("privacy_mail")
         self.privacy_pdo = params.get("privacy_pdo")
         self.privacy_supervisor = params.get("privacy_supervisor")
-        self.mail_basedir = Path(f"/home/vmail/mail/{self.mail_domain}")
+        self.mail_basedir = mail_basedir
 
     def _getbytefile(self):
         return open(self._inipath, "rb")

--- a/chatmaild/src/chatmaild/config.py
+++ b/chatmaild/src/chatmaild/config.py
@@ -13,7 +13,7 @@ def read_config(inipath, mail_basedir=None):
 
 
 class Config:
-    def __init__(self, inipath, params, mail_basedir):
+    def __init__(self, inipath, params, mail_basedir: Path):
         self._inipath = inipath
         self.mail_domain = params["mail_domain"]
         self.max_user_send_per_minute = int(params["max_user_send_per_minute"])

--- a/chatmaild/src/chatmaild/config.py
+++ b/chatmaild/src/chatmaild/config.py
@@ -4,6 +4,7 @@ import iniconfig
 
 
 def read_config(inipath, mail_basedir=None):
+    assert Path(inipath).exists(), inipath
     cfg = iniconfig.IniConfig(inipath)
     params = cfg.sections["params"]
     if mail_basedir is None:

--- a/chatmaild/src/chatmaild/config.py
+++ b/chatmaild/src/chatmaild/config.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import iniconfig
 
 
@@ -25,9 +27,15 @@ class Config:
         self.privacy_mail = params.get("privacy_mail")
         self.privacy_pdo = params.get("privacy_pdo")
         self.privacy_supervisor = params.get("privacy_supervisor")
+        self.mail_basedir = Path(f"/home/vmail/mail/{self.mail_domain}")
 
     def _getbytefile(self):
         return open(self._inipath, "rb")
+
+    def get_user_maildir(self, addr):
+        if not addr or "/" in addr:
+            raise ValueError(addr)
+        return self.mail_basedir.joinpath(addr)
 
 
 def write_initial_config(inipath, mail_domain):

--- a/chatmaild/src/chatmaild/delete_inactive_users.py
+++ b/chatmaild/src/chatmaild/delete_inactive_users.py
@@ -1,5 +1,5 @@
 """
-Remove old user accounts
+Remove inactive users
 """
 
 import shutil

--- a/chatmaild/src/chatmaild/delete_inactive_users.py
+++ b/chatmaild/src/chatmaild/delete_inactive_users.py
@@ -8,7 +8,7 @@ import time
 
 from .config import read_config
 from .database import Database
-from .doveauth import get_stale_users
+from .doveauth import iter_userdb_lastlogin_before
 
 
 def remove_user(db, config, user):
@@ -18,11 +18,14 @@ def remove_user(db, config, user):
         conn.execute("DELETE FROM users WHERE addr = ?", (user,))
 
 
+def delete_inactive_users(db, config):
+    cutoff_date = time.time() - config.delete_inactive_users_after * 86400
+    for user in iter_userdb_lastlogin_before(db, cutoff_date):
+        remove_user(db, config, user)
+        print(f"Deleted user: {user}")
+
+
 def main():
     db = Database(sys.argv[1])
     config = read_config(sys.argv[2])
-    cutoff_date = time.time() - config.delete_accounts_after * 86400
-
-    for user in get_stale_users(db, cutoff_date):
-        remove_user(db, config, user)
-        print(f"Deleted user: {user}")
+    delete_inactive_users(db, config)

--- a/chatmaild/src/chatmaild/doveauth.py
+++ b/chatmaild/src/chatmaild/doveauth.py
@@ -124,7 +124,7 @@ def lookup_passdb(db, config: Config, user, cleartext_password, last_login=None)
         q = """INSERT INTO users (addr, password, last_login)
                VALUES (?, ?, ?)"""
         conn.execute(q, (user, encrypted_password, last_login))
-        print(f"Created account {user}", file=sys.stderr)
+        print(f"Created e-mail address: {user}", file=sys.stderr)
         return dict(
             home=f"/home/vmail/mail/{config.mail_domain}/{user}",
             uid="vmail",

--- a/chatmaild/src/chatmaild/doveauth.py
+++ b/chatmaild/src/chatmaild/doveauth.py
@@ -124,7 +124,7 @@ def lookup_passdb(db, config: Config, user, cleartext_password, last_login=None)
         q = """INSERT INTO users (addr, password, last_login)
                VALUES (?, ?, ?)"""
         conn.execute(q, (user, encrypted_password, last_login))
-        print(f"Created e-mail address: {user}", file=sys.stderr)
+        print(f"Created address: {user}", file=sys.stderr)
         return dict(
             home=f"/home/vmail/mail/{config.mail_domain}/{user}",
             uid="vmail",
@@ -146,7 +146,7 @@ def iter_userdb_lastlogin_before(db, cutoff_date):
     """Get a list of users where last login was before cutoff_date."""
     with db.read_connection() as conn:
         rows = conn.execute(
-            "SELECT addr FROM users WHERE last_login <?", (cutoff_date,)
+            "SELECT addr FROM users WHERE last_login < ?", (cutoff_date,)
         ).fetchall()
     return [x[0] for x in rows]
 

--- a/chatmaild/src/chatmaild/doveauth.py
+++ b/chatmaild/src/chatmaild/doveauth.py
@@ -103,7 +103,8 @@ def lookup_passdb(db, config: Config, user, cleartext_password, last_login=None)
         )
 
     if last_login is None:
-        last_login = int(time.time())
+        last_login = time.time()
+    last_login = int(last_login)
 
     with db.write_transaction() as conn:
         userdata = conn.get_user(user)

--- a/chatmaild/src/chatmaild/ini/chatmail.ini.f
+++ b/chatmaild/src/chatmaild/ini/chatmail.ini.f
@@ -8,17 +8,20 @@ mail_domain = {mail_domain}
 #
 
 #
-# Account Restrictions
+# Restrictions on user addresses 
 #
 
 # how many mails a user can send out per minute
 max_user_send_per_minute = 60
 
-# maximum mailbox size of a chatmail account
+# maximum mailbox size of a chatmail address
 max_mailbox_size = 100M
 
 # days after which mails are unconditionally deleted
 delete_mails_after = 20
+
+# days after which users without a login are deleted (database and mails) 
+delete_inactive_users_after = 25
 
 # minimum length a username must have
 username_min_length = 9
@@ -29,7 +32,7 @@ username_max_length = 9
 # minimum length a password must have
 password_min_length = 9
 
-# list of chatmail accounts which can send outbound un-encrypted mail
+# list of chatmail addresses which can send outbound un-encrypted mail
 passthrough_senders =
 
 # list of e-mail recipients for which to accept outbound un-encrypted mails

--- a/chatmaild/src/chatmaild/ini/chatmail.ini.f
+++ b/chatmaild/src/chatmaild/ini/chatmail.ini.f
@@ -8,7 +8,7 @@ mail_domain = {mail_domain}
 #
 
 #
-# Restrictions on user addresses 
+# Restrictions on user addresses
 #
 
 # how many mails a user can send out per minute
@@ -20,7 +20,7 @@ max_mailbox_size = 100M
 # days after which mails are unconditionally deleted
 delete_mails_after = 20
 
-# days after which users without a login are deleted (database and mails) 
+# days after which users without a login are deleted (database and mails)
 delete_inactive_users_after = 25
 
 # minimum length a username must have

--- a/chatmaild/src/chatmaild/remove_stale_users.py
+++ b/chatmaild/src/chatmaild/remove_stale_users.py
@@ -1,0 +1,28 @@
+"""
+Remove old user accounts
+"""
+
+import shutil
+import sys
+import time
+
+from .config import read_config
+from .database import Database
+from .doveauth import get_stale_users
+
+
+def remove_user(db, config, user):
+    user_mail_dir = config.get_user_maildir(user)
+    shutil.rmtree(user_mail_dir, ignore_errors=True)
+    with db.write_transaction() as conn:
+        conn.execute("DELETE FROM users WHERE addr = ?", (user,))
+
+
+def main():
+    db = Database(sys.argv[1])
+    config = read_config(sys.argv[2])
+    cutoff_date = time.time() - config.delete_accounts_after * 86400
+
+    for user in get_stale_users(db, cutoff_date):
+        remove_user(db, config, user)
+        print(f"Deleted user: {user}")

--- a/chatmaild/src/chatmaild/tests/plugin.py
+++ b/chatmaild/src/chatmaild/tests/plugin.py
@@ -17,7 +17,9 @@ def make_config(tmp_path):
 
     def make_conf(mail_domain):
         write_initial_config(inipath, mail_domain=mail_domain)
-        return read_config(inipath)
+        basedir = tmp_path.joinpath(f"vmail/{mail_domain}")
+        basedir.mkdir(parents=True, exist_ok=True)
+        return read_config(inipath, mail_basedir=basedir)
 
     return make_conf
 

--- a/chatmaild/src/chatmaild/tests/test_config.py
+++ b/chatmaild/src/chatmaild/tests/test_config.py
@@ -43,7 +43,15 @@ def test_get_user_maildir(make_config):
 
     with pytest.raises(ValueError):
         config.get_user_maildir("")
+
     with pytest.raises(ValueError):
         config.get_user_maildir(None)
+
     with pytest.raises(ValueError):
         config.get_user_maildir("../some@something.testrun.org")
+
+    with pytest.raises(ValueError):
+        config.get_user_maildir("..")
+
+    with pytest.raises(ValueError):
+        config.get_user_maildir(".")

--- a/chatmaild/src/chatmaild/tests/test_config.py
+++ b/chatmaild/src/chatmaild/tests/test_config.py
@@ -1,3 +1,4 @@
+import pytest
 from chatmaild.config import read_config
 
 
@@ -30,3 +31,19 @@ def test_read_config_testrun(make_config):
     assert config.password_min_length == 9
     assert "privacy@testrun.org" in config.passthrough_recipients
     assert config.passthrough_senders == []
+
+
+def test_get_user_maildir(make_config):
+    config = make_config("something.testrun.org")
+    assert config.mail_basedir.name == "something.testrun.org"
+    assert config.mail_domain == "something.testrun.org"
+    path = config.get_user_maildir("user1@something.testrun.org")
+    assert not path.exists()
+    assert path == config.mail_basedir.joinpath("user1@something.testrun.org")
+
+    with pytest.raises(ValueError):
+        config.get_user_maildir("")
+    with pytest.raises(ValueError):
+        config.get_user_maildir(None)
+    with pytest.raises(ValueError):
+        config.get_user_maildir("../some@something.testrun.org")

--- a/chatmaild/src/chatmaild/tests/test_delete_inactive_users.py
+++ b/chatmaild/src/chatmaild/tests/test_delete_inactive_users.py
@@ -1,0 +1,34 @@
+from time import time as now
+
+from chatmaild.doveauth import lookup_passdb
+from chatmaild.delete_inactive_users import delete_inactive_users
+
+
+def test_remove_stale_users(db, example_config):
+    old = now() - (example_config.delete_inactive_users_after * 86400) - 1000
+    new = old + 1001
+
+    def create_user(addr, last_login):
+        lookup_passdb(db, example_config, addr, "q9mr3faue", last_login=last_login)
+        md = example_config.get_user_maildir(addr)
+        md.mkdir(parents=True)
+        md.joinpath("cur").mkdir()
+        md.joinpath("cur", "something").mkdir()
+
+    for i in range(10):
+        create_user(f"oldold{i:03}@chat.example.org", last_login=old)
+
+    remain = []
+    for i in range(5):
+        create_user(f"newnew{i:03}@chat.example.org", last_login=new)
+
+    udir = example_config.get_user_maildir("oldold001@chat.example.org")
+    assert udir.exists()
+
+    delete_inactive_users(db, example_config)
+
+    for p in udir.parent.iterdir():
+        assert not p.name.startswith("old")
+
+    for addr in remain:
+        assert example_config.get_user_maildir(addr).exists()

--- a/chatmaild/src/chatmaild/tests/test_delete_inactive_users.py
+++ b/chatmaild/src/chatmaild/tests/test_delete_inactive_users.py
@@ -1,12 +1,12 @@
-from time import time as now
+import time
 
 from chatmaild.delete_inactive_users import delete_inactive_users
 from chatmaild.doveauth import lookup_passdb
 
 
 def test_remove_stale_users(db, example_config):
-    old = now() - (example_config.delete_inactive_users_after * 86400) - 1000
-    new = old + 1001
+    new = time.time()
+    old = new - (example_config.delete_inactive_users_after * 86400) - 1
 
     def create_user(addr, last_login):
         lookup_passdb(db, example_config, addr, "q9mr3faue", last_login=last_login)

--- a/chatmaild/src/chatmaild/tests/test_delete_inactive_users.py
+++ b/chatmaild/src/chatmaild/tests/test_delete_inactive_users.py
@@ -1,7 +1,7 @@
 from time import time as now
 
-from chatmaild.doveauth import lookup_passdb
 from chatmaild.delete_inactive_users import delete_inactive_users
+from chatmaild.doveauth import lookup_passdb
 
 
 def test_remove_stale_users(db, example_config):

--- a/chatmaild/src/chatmaild/tests/test_doveauth.py
+++ b/chatmaild/src/chatmaild/tests/test_doveauth.py
@@ -13,6 +13,7 @@ from chatmaild.doveauth import (
     handle_dovecot_request,
     is_allowed_to_create,
     iter_userdb,
+    iter_userdb_lastlogin_before,
     lookup_passdb,
 )
 from chatmaild.newemail import create_newemail_dict
@@ -34,8 +35,27 @@ def test_iterate_addresses(db, example_config):
     for i in range(10):
         addresses.append(f"asdf1234{i}@chat.example.org")
         lookup_passdb(db, example_config, addresses[-1], "q9mr3faue")
-    res = iter_userdb(db, example_config)
+    res = iter_userdb(db)
     assert res == addresses
+
+
+def test_iterate_addresses_lastlogin_before(db, example_config):
+    addresses = []
+
+    cutoff_date = 1000
+    for i in range(10):
+        addr = f"oldold{i:03}@chat.example.org"
+        lookup_passdb(
+            db, example_config, addr, "q9mr3faue", last_login=cutoff_date - 10
+        )
+        addresses.append(addr)
+
+    for i in range(5):
+        addr = f"newnew{i:03}@chat.example.org"
+        lookup_passdb(db, example_config, addr, "q9mr3faue", last_login=cutoff_date + i)
+
+    res = iter_userdb_lastlogin_before(db, cutoff_date)
+    assert sorted(res) == sorted(addresses)
 
 
 def test_invalid_username_length(example_config):

--- a/cmdeploy/src/cmdeploy/dovecot/expunge.cron.j2
+++ b/cmdeploy/src/cmdeploy/dovecot/expunge.cron.j2
@@ -9,4 +9,4 @@
 2 0 * * * vmail find /home/vmail/mail/{{ config.mail_domain }} -path '*/tmp/*' -mtime +{{ config.delete_mails_after }} -type f -delete
 2 0 * * * vmail find /home/vmail/mail/{{ config.mail_domain }} -path '*/.*/tmp/*' -mtime +{{ config.delete_mails_after }} -type f -delete
 3 0 * * * vmail find /home/vmail/mail/{{ config.mail_domain }} -name 'maildirsize' -type f -delete
-4 0 * * * vmail /usr/local/lib/chatmaild/venv/bin/delete_inactive_users /home/vmail/passdb.lite /usr/local/lib/chatmaild/chatmail.ini 
+4 0 * * * vmail /usr/local/lib/chatmaild/venv/bin/delete_inactive_users /home/vmail/passdb.sqlite /usr/local/lib/chatmaild/chatmail.ini 

--- a/cmdeploy/src/cmdeploy/dovecot/expunge.cron.j2
+++ b/cmdeploy/src/cmdeploy/dovecot/expunge.cron.j2
@@ -9,3 +9,4 @@
 2 0 * * * vmail find /home/vmail/mail/{{ config.mail_domain }} -path '*/tmp/*' -mtime +{{ config.delete_mails_after }} -type f -delete
 2 0 * * * vmail find /home/vmail/mail/{{ config.mail_domain }} -path '*/.*/tmp/*' -mtime +{{ config.delete_mails_after }} -type f -delete
 3 0 * * * vmail find /home/vmail/mail/{{ config.mail_domain }} -name 'maildirsize' -type f -delete
+4 0 * * * vmail /usr/local/lib/chatmaild/venv/bin/delete_inactive_users /home/vmail/passdb.lite /usr/local/lib/chatmaild/chatmail.ini 


### PR DESCRIPTION
fixes #295 
supersedes #327 

this adds a new chatmaild entry point `delete_inactive_users` which removes all user state for users which didn't log in for `delete_inactive_users_after` days (defaulting to 25). 
