### PR TITLE
Accept encrypted messages that use hcp_minimal

### DIFF
--- a/chatmaild/src/chatmaild/filtermail.py
+++ b/chatmaild/src/chatmaild/filtermail.py
@@ -111,7 +111,7 @@ def check_encrypted(message):
     """
     if not message.is_multipart():
         return False
-    if message.get("subject") != "...":
+    if message.get("subject") not in {"...", "[...]"}:
         return False
     if message.get_content_type() != "multipart/encrypted":
         return False

--- a/chatmaild/src/chatmaild/tests/mail-data/encrypted.eml
+++ b/chatmaild/src/chatmaild/tests/mail-data/encrypted.eml
@@ -1,6 +1,6 @@
 From: {from_addr}
 To: {to_addr}
-Subject: ...
+Subject: {replaced_subject}
 Date: Sun, 15 Oct 2023 16:43:21 +0000
 Message-ID: <Mr.UVyJWZmkCKM.hGzNc6glBE_@c2.testrun.org>
 In-Reply-To: <Mr.MvmCz-GQbi_.6FGRkhDf05c@c2.testrun.org>

--- a/chatmaild/src/chatmaild/tests/plugin.py
+++ b/chatmaild/src/chatmaild/tests/plugin.py
@@ -71,11 +71,11 @@ def maildata(request):
 
     assert datadir.exists(), datadir
 
-    def maildata(name, from_addr, to_addr):
+    def maildata(name, **kwargs):
         # Using `.read_bytes().decode()` instead of `.read_text()` to preserve newlines.
         data = datadir.joinpath(name).read_bytes().decode()
 
-        text = data.format(from_addr=from_addr, to_addr=to_addr)
+        text = data.format(**kwargs)
         return BytesParser(policy=policy.default).parsebytes(text.encode())
 
     return maildata

--- a/chatmaild/src/chatmaild/tests/test_filtermail.py
+++ b/chatmaild/src/chatmaild/tests/test_filtermail.py
@@ -54,10 +54,16 @@ def test_filtermail_no_encryption_detection(maildata):
 
 
 def test_filtermail_encryption_detection(maildata):
-    msg = maildata("encrypted.eml", from_addr="1@example.org", to_addr="2@example.org")
-    assert check_encrypted(msg)
+    for subject in ("...", "[...]"):
+        msg = maildata(
+            "encrypted.eml",
+            from_addr="1@example.org",
+            to_addr="2@example.org",
+            replaced_subject=subject,
+        )
+        assert check_encrypted(msg)
 
-    # if the subject is not "..." it is not considered ac-encrypted
+    # if the subject is not a known encrypted subject value, it is not considered ac-encrypted
     msg.replace_header("Subject", "Click this link")
     assert not check_encrypted(msg)
 
@@ -72,7 +78,7 @@ def test_filtermail_unencrypted_mdn(maildata, gencreds):
     """Unencrypted MDNs should not pass."""
     from_addr = gencreds()[0]
     to_addr = gencreds()[0] + ".other"
-    msg = maildata("mdn.eml", from_addr, to_addr)
+    msg = maildata("mdn.eml", from_addr=from_addr, to_addr=to_addr)
 
     assert not check_encrypted(msg)
 
@@ -95,7 +101,7 @@ def test_excempt_privacy(maildata, gencreds, handler):
     handler.config.passthrough_recipients = [to_addr]
     false_to = "privacy@something.org"
 
-    msg = maildata("plain.eml", from_addr, to_addr)
+    msg = maildata("plain.eml", from_addr=from_addr, to_addr=to_addr)
 
     class env:
         mail_from = from_addr
@@ -118,7 +124,7 @@ def test_passthrough_senders(gencreds, handler, maildata):
     to_addr = "recipient@something.org"
     handler.config.passthrough_senders = [acc1]
 
-    msg = maildata("plain.eml", acc1, to_addr)
+    msg = maildata("plain.eml", from_addr=acc1, to_addr=to_addr)
 
     class env:
         mail_from = acc1


### PR DESCRIPTION
in draft-ietf-lamps-header-protection-22, hcp_minimal recommends "[...]" as the obscured Subject header.  In the pending draft -23 (hopefully released this week, going into a working group last call), the same HCP will be renamed to hcp_baseline, but it still recommends the use of "[...]" for the obscured Subject header.