### PR TITLE
Fix doveauth logging for created accounts

### DIFF
--- a/chatmaild/src/chatmaild/doveauth.py
+++ b/chatmaild/src/chatmaild/doveauth.py
@@ -141,7 +141,7 @@ class AuthDictProxy(DictProxy):
             return
 
         user.set_password(encrypt_password(cleartext_password))
-        print(f"Created address: {user}", file=sys.stderr)
+        print(f"Created address: {addr}", file=sys.stderr)
         return user.get_userdb_dict()
 
 


### PR DESCRIPTION
Currently logs look like this:
`Created address: <chatmaild.user.User object at 0x7fafac36bcd0>`