### PR TITLE
allow dictproxy subclasses to be ignorant of transactions in handle_set operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## untagged 
 
+- fix metadata dictproxy which would confuse transactions
+  resulting in missed notifications and other issues. 
+  ([#393](https://github.com/deltachat/chatmail/pull/388))
+  ([#394](https://github.com/deltachat/chatmail/pull/389))
+
 - add optional "imap_rawlog" config option. If true, 
   .in/.out files are created in user home dirs 
   containing the imap protocol messages. 

--- a/chatmaild/src/chatmaild/dictproxy.py
+++ b/chatmaild/src/chatmaild/dictproxy.py
@@ -44,7 +44,10 @@ class DictProxy:
         elif short_command == "C":
             return self.handle_commit_transaction(transaction_id, parts, transactions)
         elif short_command == "S":
-            return self.handle_set(transaction_id, parts, transactions)
+            addr = transactions[transaction_id]["addr"]
+            if not self.handle_set(addr, parts):
+                transactions[transaction_id]["res"] = "F\n"
+                logging.error(f"dictproxy-set failed for {addr!r}: {msg!r}")
 
     def handle_lookup(self, parts):
         logging.warning(f"lookup ignored: {parts!r}")
@@ -59,11 +62,10 @@ class DictProxy:
         addr = parts[1]
         transactions[transaction_id] = dict(addr=addr, res="O\n")
 
-    def handle_set(self, transaction_id, parts, transactions):
+    def handle_set(self, addr, parts):
         # For documentation on key structure see
         # https://github.com/dovecot/core/blob/main/src/lib-storage/mailbox-attribute.h
-
-        transactions[transaction_id]["res"] = "F\n"
+        return False
 
     def handle_commit_transaction(self, transaction_id, parts, transactions):
         # return whatever "set" command(s) set as result.

--- a/chatmaild/src/chatmaild/lastlogin.py
+++ b/chatmaild/src/chatmaild/lastlogin.py
@@ -9,20 +9,19 @@ class LastLoginDictProxy(DictProxy):
         super().__init__()
         self.config = config
 
-    def handle_set(self, transaction_id, parts, transactions):
+    def handle_set(self, addr, parts):
         keyname = parts[1].split("/")
         value = parts[2] if len(parts) > 2 else ""
-        addr = transactions[transaction_id]["addr"]
         if keyname[0] == "shared" and keyname[1] == "last-login":
             if addr.startswith("echo@"):
-                return
+                return True
             addr = keyname[2]
             timestamp = int(value)
             user = self.config.get_user(addr)
             user.set_last_login_timestamp(timestamp)
-        else:
-            # Transaction failed.
-            transactions[transaction_id]["res"] = "F\n"
+            return True
+
+        return False
 
 
 def main():


### PR DESCRIPTION
both metadata and lastlogin subclasses of DictProxies now don't need 
to know about transactions at all. 