### PR TITLE
upgrade debian packages on "cmdeploy run"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## untagged
 
 
+- trigger "apt upgrade" during "cmdeploy run" 
+  ([#398](https://github.com/deltachat/chatmail/pull/398))
+
 ## 1.4.1 2024-07-31
 
 - fix metadata dictproxy which would confuse transactions

--- a/cmdeploy/src/cmdeploy/__init__.py
+++ b/cmdeploy/src/cmdeploy/__init__.py
@@ -489,6 +489,7 @@ def deploy_chatmail(config_path: Path) -> None:
     )
 
     apt.update(name="apt update", cache_time=24 * 3600)
+    apt.upgrade(name="upgrade apt packages", auto_remove=True)
 
     apt.packages(
         name="Install rsync",


### PR DESCRIPTION
fixes #397

we could also install "unattended-upgrades" but this might disrupt services at unexpected times so i left that out for now. 
ugprading only happens at "cmdeploy run" time. 