### PR TITLE
make nginx not listen on ipv6 if v6 is disabled. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## untagged
 
+- avoid nginx listening on ipv6 if v6 is dsiabled 
+  ([#402](https://github.com/deltachat/chatmail/pull/402))
 
 - trigger "apt upgrade" during "cmdeploy run" 
   ([#398](https://github.com/deltachat/chatmail/pull/398))

--- a/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
+++ b/cmdeploy/src/cmdeploy/nginx/nginx.conf.j2
@@ -19,7 +19,9 @@ stream {
 
         server {
                 listen 443;
+                {% if not disable_ipv6 %}
                 listen [::]:443;
+                {% endif %}
                 proxy_pass $proxy;
                 ssl_preread on;
         }


### PR DESCRIPTION
fixes #399 