### PR TITLE
add a note on deletion of accounts

### DIFF
--- a/chatmaild/src/chatmaild/ini/chatmail.ini.f
+++ b/chatmaild/src/chatmaild/ini/chatmail.ini.f
@@ -23,8 +23,8 @@ max_message_size = 31457280
 # days after which mails are unconditionally deleted
 delete_mails_after = 20
 
-# days after which users without a login are deleted (database and mails)
-delete_inactive_users_after = 100
+# days after which users without a successful login are deleted (database and mails)
+delete_inactive_users_after = 90
 
 # minimum length a username must have
 username_min_length = 9

--- a/www/src/info.md
+++ b/www/src/info.md
@@ -43,6 +43,20 @@ The first login sets your password.
 - You can store up to [{{ config.max_mailbox_size }} messages on the server](https://delta.chat/en/help#what-happens-if-i-turn-on-delete-old-messages-from-server).
 
 
+### <a name="account-deletion"></a> Account deletion 
+
+If you remove a {{ config.mail_domain }} profile from within the Delta Chat app, 
+then the according account on the server, along with all associated data,
+is automatically deleted {{ config.delete_inactive_users_after }} days afterwards. 
+
+If you use multiple devices 
+then you need to remove the according chat profile from each device
+in order for all account data to be removed on the server side. 
+
+If you have any further questions or requests regarding account deletion
+please send a message from your account to {{ config.privacy_mail }}. 
+
+
 ### Who are the operators? Which software is running? 
 
 This chatmail provider is run by a small voluntary group of devs and sysadmins,


### PR DESCRIPTION
fixes #405 

also lowers the inactive account deletion to 90 days by default. 
