### PR TITLE
docs: more details for the repo overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ This repository has four directories:
 - [cmdeploy](https://github.com/deltachat/chatmail/tree/main/cmdeploy)
   is a collection of configuration files
   and a [pyinfra](https://pyinfra.com)-based deployment script.
+
 - [chatmaild](https://github.com/deltachat/chatmail/tree/main/chatmaild)
   is a python package containing several small services
   which handle authentication,
@@ -93,10 +94,12 @@ This repository has four directories:
   delete inactive users,
   and some other minor things.
   chatmaild can also be installed as a stand-alone python package.
+
 - [www](https://github.com/deltachat/chatmail/tree/main/www)
   contains the html, css, and markdown files
   which make up a chatmail server's web page.
   Edit them before deploying to make your chatmail server stand out.
+
 - [scripts](https://github.com/deltachat/chatmail/tree/main/scripts)
   offers two convenience tools for beginners;
   `initenv.sh` installs the necessary dependencies to a local virtual environment,
@@ -115,11 +118,17 @@ according to the `chatmail.ini` config.
 The components of chatmail are:
 
 - [postfix smtp server](https://www.postfix.org) accepts sent messages (both from your users and from other servers)
+
 - [dovecot imap server](https://www.dovecot.org) stores messages for your users until they download them
+
 - [nginx](https://nginx.org/) shows the web page with your privacy policy and additional information
+
 - [acmetool](https://hlandau.github.io/acmetool/) manages TLS certificates for dovecot, postfix, and nginx
+
 - [opendkim](http://www.opendkim.org/) for signing messages with DKIM and rejecting inbound messages without DKIM
+
 - [mtail](https://google.github.io/mtail/) for collecting anonymized metrics in case you have monitoring
+
 - and the chatmaild services, explained in the next section:
 
 ### chatmaild
@@ -136,9 +145,11 @@ A short overview:
   which in turn uses [Dovecot SASL](https://doc.dovecot.org/configuration_manual/authentication/dict/#complete-example-for-authenticating-via-a-unix-socket)
   to authenticate users
   to send mails for them.
+
 - [`filtermail`](https://github.com/deltachat/chatmail/blob/main/chatmaild/src/chatmaild/filtermail.py) prevents
   unencrypted e-mail from leaving the chatmail service
   and is integrated into postfix's outbound mail pipelines.
+
 - [`chatmail-metadata`](https://github.com/deltachat/chatmail/blob/main/chatmaild/src/chatmaild/metadata.py) is contacted by a
   [dovecot lua script](https://github.com/deltachat/chatmail/blob/main/cmdeploy/src/cmdeploy/dovecot/push_notification.lua)
   to store user-specific server-side config.
@@ -147,15 +158,19 @@ A short overview:
   to [notifications.delta.chat](https://delta.chat/help#instant-delivery)
   so the push notifications on the user's phone can be triggered
   by Apple/Google.
+
 - [`delete_inactive_users`](https://github.com/deltachat/chatmail/blob/main/chatmaild/src/chatmaild/delete_inactive_users.py)
   deletes users if they have not logged in for a very long time.
   The timeframe can be configured in `chatmail.ini`.
+
 - [`lastlogin`](https://github.com/deltachat/chatmail/blob/main/chatmaild/src/chatmaild/lastlogin.py)
   is contacted by dovecot when a user logs in
   and stores the date of the login.
+
 - [`echobot`](https://github.com/deltachat/chatmail/blob/main/chatmaild/src/chatmaild/echo.py)
   is a small bot for test purposes.
   It simply echoes back messages from users.
+
 - [`chatmail-metrics`](https://github.com/deltachat/chatmail/blob/main/chatmaild/src/chatmaild/metrics.py)
   collects some metrics and displays them at `https://example.org/metrics`.
 

--- a/README.md
+++ b/README.md
@@ -107,9 +107,12 @@ This repository has four directories:
 
 The `cmdeploy/src/cmdeploy/cmdeploy.py` command line tool
 helps with setting up and managing the chatmail service.
-`cmdeploy run` uses [pyinfra-based scripting](https://pyinfra.com/)
-in `cmdeploy/src/cmdeploy/__init__.py`
-to automatically install all chatmail components on a server:
+`cmdeploy init` creates the `chatmail.ini` config file.
+`cmdeploy run` uses a [pyinfra](https://pyinfra.com/)-based [script](`cmdeploy/src/cmdeploy/__init__.py`)
+to automatically install or upgrade all chatmail components on a server,
+according to the `chatmail.ini` config.
+
+The components of chatmail are:
 
 - [postfix smtp server](https://www.postfix.org) accepts sent messages (both from your users and from other servers)
 - [dovecot imap server](https://www.dovecot.org) stores messages for your users until they download them


### PR DESCRIPTION
fix #419 

I decided against mentioning that you can modify the chatmail.ini on the server and restart a chatmaild service to make it use the new value on runtime. Admins don't need to know that there is even a copy of the config file on the server; editing it is a bad idea anyway.