### PR TITLE
ci: test `cmdeploy dns` only once

### DIFF
--- a/.github/workflows/test-and-deploy-ipv4only.yaml
+++ b/.github/workflows/test-and-deploy-ipv4only.yaml
@@ -93,6 +93,6 @@ jobs:
       - name: cmdeploy test
         run: CHATMAIL_DOMAIN2=nine.testrun.org cmdeploy test --slow
 
-      - name: cmdeploy dns (try 3 times)
-        run: cmdeploy dns || cmdeploy dns || cmdeploy dns
+      - name: cmdeploy dns
+        run: cmdeploy dns -v
 

--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -91,6 +91,6 @@ jobs:
       - name: cmdeploy test
         run: CHATMAIL_DOMAIN2=nine.testrun.org cmdeploy test --slow
 
-      - name: cmdeploy dns (try 3 times)
-        run: cmdeploy dns -v || cmdeploy dns -v || cmdeploy dns -v
+      - name: cmdeploy dns
+        run: cmdeploy dns -v
 


### PR DESCRIPTION
It should be reliable since https://github.com/deltachat/chatmail/pull/424 is merged.