### PR TITLE
cmdeploy: flag to disable postfix + dovecot for migration

### DIFF
--- a/cmdeploy/src/cmdeploy/__init__.py
+++ b/cmdeploy/src/cmdeploy/__init__.py
@@ -479,10 +479,11 @@ def deploy_mtail(config):
     )
 
 
-def deploy_chatmail(config_path: Path) -> None:
+def deploy_chatmail(config_path: Path, disable_mail: bool) -> None:
     """Deploy a chat-mail instance.
 
     :param config_path: path to chatmail.ini
+    :param disable_mail: whether to disable postfix & dovecot
     """
     config = read_config(config_path)
     check_config(config)
@@ -624,19 +625,19 @@ def deploy_chatmail(config_path: Path) -> None:
     # because it creates authentication socket
     # required by Postfix.
     systemd.service(
-        name="Start and enable Dovecot",
+        name="disable dovecot for now" if disable_mail else "Start and enable Dovecot",
         service="dovecot.service",
-        running=True,
-        enabled=True,
-        restarted=dovecot_need_restart,
+        running=False if disable_mail else True,
+        enabled=False if disable_mail else True,
+        restarted=dovecot_need_restart if not disable_mail else False,
     )
 
     systemd.service(
-        name="Start and enable Postfix",
+        name="disable postfix for now" if disable_mail else "Start and enable Postfix",
         service="postfix.service",
-        running=True,
-        enabled=True,
-        restarted=postfix_need_restart,
+        running=False if disable_mail else True,
+        enabled=False if disable_mail else True,
+        restarted=postfix_need_restart if not disable_mail else False,
     )
 
     systemd.service(

--- a/cmdeploy/src/cmdeploy/cmdeploy.py
+++ b/cmdeploy/src/cmdeploy/cmdeploy.py
@@ -52,6 +52,12 @@ def run_cmd_options(parser):
         action="store_true",
         help="don't actually modify the server",
     )
+    parser.add_argument(
+        "--disable-mail",
+        dest="disable_mail",
+        action="store_true",
+        help="install/upgrade the server, but disable postfix & dovecot for now"
+    )
 
 
 def run_cmd(args, out):
@@ -64,6 +70,7 @@ def run_cmd(args, out):
 
     env = os.environ.copy()
     env["CHATMAIL_INI"] = args.inipath
+    env["CHATMAIL_DISABLE_MAIL"] = "True" if args.disable_mail else ""
     deploy_path = importlib.resources.files(__package__).joinpath("deploy.py").resolve()
     pyinf = "pyinfra --dry" if args.dry_run else "pyinfra"
     cmd = f"{pyinf} --ssh-user root {args.config.mail_domain} {deploy_path} -y"

--- a/cmdeploy/src/cmdeploy/deploy.py
+++ b/cmdeploy/src/cmdeploy/deploy.py
@@ -11,8 +11,9 @@ def main():
         "CHATMAIL_INI",
         importlib.resources.files("cmdeploy").joinpath("../../../chatmail.ini"),
     )
+    disable_mail = bool(os.environ.get('CHATMAIL_DISABLE_MAIL'))
 
-    deploy_chatmail(config_path)
+    deploy_chatmail(config_path, disable_mail)
 
 
 if pyinfra.is_cli:


### PR DESCRIPTION
Migration is still not super nice because it required me to do a lot of back-and-forth in my local /etc/hosts file, and keep track of "which certificates are on which server now, where does DNS point already, and for who..."

But this made it work in principle.

Note that postfix will still be reachable for a while during the initial `cmdeploy run --disable-mail` command on the new server, so if DNS is already pointing to it, some messages will be sucked into the void. I will write a migration guide which avoids this.