### PR TITLE
Dovecot quota_max_mail_size to use the Chatmail max_message_size value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 - fix OpenPGP payload check
   ([#435](https://github.com/deltachat/chatmail/pull/435))
 
+- fix Dovecot quota_max_mail_size to use max_message_size config value
+
 
 ## 1.4.1 2024-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
   ([#435](https://github.com/deltachat/chatmail/pull/435))
 
 - fix Dovecot quota_max_mail_size to use max_message_size config value
+  ([#438](https://github.com/deltachat/chatmail/pull/438))
 
 
 ## 1.4.1 2024-07-31

--- a/cmdeploy/src/cmdeploy/dovecot/dovecot.conf.j2
+++ b/cmdeploy/src/cmdeploy/dovecot/dovecot.conf.j2
@@ -141,7 +141,7 @@ plugin {
   # for now we define static quota-rules for all users 
   quota = maildir:User quota
   quota_rule = *:storage={{ config.max_mailbox_size }}
-  quota_max_mail_size=30M
+  quota_max_mail_size={{ config.max_message_size }}
   quota_grace = 0
   # quota_over_flag_value = TRUE
 }


### PR DESCRIPTION
for consistency with the limit applied to Postfix