### PR TITLE
DNS: always show recommended DNS records

### DIFF
--- a/.github/workflows/test-and-deploy-ipv4only.yaml
+++ b/.github/workflows/test-and-deploy-ipv4only.yaml
@@ -96,5 +96,5 @@ jobs:
         run: CHATMAIL_DOMAIN2=nine.testrun.org cmdeploy test --slow
 
       - name: cmdeploy dns
-        run: cmdeploy dns -v --all
+        run: cmdeploy dns -v
 

--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -94,5 +94,5 @@ jobs:
         run: CHATMAIL_DOMAIN2=nine.testrun.org cmdeploy test --slow
 
       - name: cmdeploy dns
-        run: cmdeploy dns -v --all
+        run: cmdeploy dns -v
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## 1.5.0 2024-12-20
 
+- cmdeploy dns: always show recommended DNS records
+  ([#463](https://github.com/deltachat/chatmail/pull/463))
+
 - add `--all` to `cmdeploy dns`
   ([#462](https://github.com/deltachat/chatmail/pull/462))
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ scripts/cmdeploy status
 To display and check all recommended DNS records:
 
 ```
-scripts/cmdeploy dns --all
+scripts/cmdeploy dns
 ```
 
 To test whether your chatmail service is working correctly:

--- a/cmdeploy/src/cmdeploy/cmdeploy.py
+++ b/cmdeploy/src/cmdeploy/cmdeploy.py
@@ -106,12 +106,6 @@ def dns_cmd_options(parser):
         default=None,
         help="write out a zonefile",
     )
-    parser.add_argument(
-        "--all",
-        dest="all",
-        action="store_true",
-        help="check both required and recommended DNS records"
-    )
 
 
 def dns_cmd(args, out):
@@ -137,7 +131,7 @@ def dns_cmd(args, out):
         return 0
 
     retcode = dns.check_full_zone(
-        sshexec, remote_data=remote_data, zonefile=zonefile, out=out, all=args.all
+        sshexec, remote_data=remote_data, zonefile=zonefile, out=out
     )
     return retcode
 

--- a/cmdeploy/src/cmdeploy/dns.py
+++ b/cmdeploy/src/cmdeploy/dns.py
@@ -40,7 +40,7 @@ def get_filled_zone_file(remote_data):
     return zonefile
 
 
-def check_full_zone(sshexec, remote_data, out, zonefile, all) -> int:
+def check_full_zone(sshexec, remote_data, out, zonefile) -> int:
     """Check existing DNS records, optionally write them to zone file
     and return (exitcode, remote_data) tuple."""
 
@@ -56,12 +56,10 @@ def check_full_zone(sshexec, remote_data, out, zonefile, all) -> int:
             out(line)
         out("")
         returncode = 1
-    if recommended_diff and (all or not required_diff):
+    if recommended_diff:
         out("WARNING: these recommended DNS entries are not set:\n")
         for line in recommended_diff:
             out(line)
-        if all:
-            returncode = 1
 
     if not (recommended_diff or required_diff):
         out.green("Great! All your DNS entries are verified and correct.")

--- a/cmdeploy/src/cmdeploy/tests/test_dns.py
+++ b/cmdeploy/src/cmdeploy/tests/test_dns.py
@@ -110,7 +110,7 @@ class TestZonefileChecks:
         parse_zonefile_into_dict(zonefile_mocked, mockdns_base, only_required=True)
         mssh = MockSSHExec()
         mockdns_base["mail_domain"] = "some.domain"
-        res = check_full_zone(mssh, mockdns_base, out=mockout, zonefile=zonefile, all=False)
+        res = check_full_zone(mssh, mockdns_base, out=mockout, zonefile=zonefile)
         assert res == 0
         assert "WARNING" in mockout.captured_plain[0]
         assert len(mockout.captured_plain) == 9
@@ -120,7 +120,7 @@ class TestZonefileChecks:
         parse_zonefile_into_dict(zonefile, mockdns_base)
         mssh = MockSSHExec()
         mockdns_base["mail_domain"] = "some.domain"
-        res = check_full_zone(mssh, mockdns_base, out=mockout, zonefile=zonefile, all=True)
+        res = check_full_zone(mssh, mockdns_base, out=mockout, zonefile=zonefile)
         assert res == 0
         assert not mockout.captured_red
         assert "correct" in mockout.captured_green[0]


### PR DESCRIPTION
There is not really a reason not to show the recommended DNS records on `cmdeploy dns`. We can re-introduce the `--all` option or something similar when we think of one.