### PR TITLE
use old crypt lib in python < 3.11

### DIFF
--- a/chatmaild/pyproject.toml
+++ b/chatmaild/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "deltachat-rpc-client",
   "filelock",
   "requests",
-  "crypt-r",
+  "crypt-r; python_version >= 3.11",
 ]
 
 [tool.setuptools]

--- a/chatmaild/src/chatmaild/doveauth.py
+++ b/chatmaild/src/chatmaild/doveauth.py
@@ -3,7 +3,10 @@ import logging
 import os
 import sys
 
-import crypt_r
+try:
+    import crypt_r
+except ImportError:
+    import crypt as crypt_r
 
 from .config import Config, read_config
 from .dictproxy import DictProxy


### PR DESCRIPTION
close #482 